### PR TITLE
ColumnRingGrid constructor fix

### DIFF
--- a/src/grids/column_ring_grid.jl
+++ b/src/grids/column_ring_grid.jl
@@ -69,7 +69,7 @@ struct ColumnRingGrid{
         arch::AbstractArchitecture,
         ::Type{NF},
         vert::AbstractVerticalSpacing,
-        mask::RingGrids.AbstractField{Bool}=convert.(Bool, ones(rings))
+        mask::RingGrids.AbstractField{Bool},
     ) where {NF} = ColumnRingGrid(arch, NF, vert, mask.grid, mask)
 
     ColumnRingGrid(


### PR DESCRIPTION
If you want to construct the `ColumnRingGrid` without `rings` you really need a `mask`, so no default arg can be used. 