### PR TITLE
Remove NF from field types (Reactant compat) 

### DIFF
--- a/src/models/coupled/land_model.jl
+++ b/src/models/coupled/land_model.jl
@@ -10,13 +10,14 @@ $(TYPEDFIELDS)
 @parameterized @kwdef struct LandModel{
         NF,
         GridType <: AbstractLandGrid{NF},
-        Vegetation <: Optional{AbstractVegetation{NF}},
-        Soil <: AbstractSoil{NF},
+        Vegetation <: Optional{AbstractVegetation},
+        Soil <: AbstractSoil,
         SEB <: AbstractSurfaceEnergyBalance,
         Hydrology <: AbstractSurfaceHydrology,
         Atmosphere <: AbstractAtmosphere,
+        Constants, # <: PhysicalConstants
         Initializer <: AbstractInitializer,
-        Timestepper <: AbstractTimeStepper{NF},
+        Timestepper <: AbstractTimeStepper,
     } <: AbstractLandModel{NF, GridType}
     "Spatial discretization"
     grid::GridType
@@ -37,7 +38,7 @@ $(TYPEDFIELDS)
     @component atmosphere::Atmosphere = PrescribedAtmosphere(eltype(grid))
 
     "Physical constants"
-    @component constants::PhysicalConstants{NF} = PhysicalConstants(eltype(grid))
+    @component constants::Constants = PhysicalConstants(eltype(grid))
 
     "State variable initializer"
     @component initializer::Initializer = DefaultInitializer(eltype(grid))

--- a/src/models/soil/soil_model.jl
+++ b/src/models/soil/soil_model.jl
@@ -9,9 +9,10 @@ $(TYPEDFIELDS)
 @parameterized @kwdef struct SoilModel{
         NF,
         GridType <: AbstractLandGrid{NF},
-        Soil <: AbstractSoil{NF},
+        Soil <: AbstractSoil,
+        Constants, # <: PhysicalConstants
         Initializer <: AbstractInitializer,
-        Timestepper <: AbstractTimeStepper{NF},
+        Timestepper <: AbstractTimeStepper,
     } <: AbstractSoilModel{NF, GridType}
     "Spatial grid type"
     grid::GridType
@@ -20,7 +21,7 @@ $(TYPEDFIELDS)
     @component soil::Soil = SoilEnergyWaterCarbon(eltype(grid))
 
     "Physical constants"
-    @component constants::PhysicalConstants{NF} = PhysicalConstants(eltype(grid))
+    @component constants::Constants = PhysicalConstants(eltype(grid))
 
     "State variable initializer"
     @component initializer::Initializer = DefaultInitializer(eltype(grid))

--- a/src/models/soil/soil_model_init.jl
+++ b/src/models/soil/soil_model_init.jl
@@ -5,9 +5,9 @@ Initializer for coupled soil energy/hydrology/biogeochemistry models.
 """
 struct SoilInitializer{
         NF,
-        EnergyInit <: AbstractInitializer{NF},
-        HydrologyInit <: AbstractInitializer{NF},
-        BGCInit <: AbstractInitializer{NF},
+        EnergyInit <: AbstractInitializer,
+        HydrologyInit <: AbstractInitializer,
+        BGCInit <: AbstractInitializer,
     } <: AbstractInitializer{NF}
     "Soil energy/temperature state initializer"
     energy::EnergyInit
@@ -19,13 +19,24 @@ struct SoilInitializer{
     biogeochem::BGCInit
 end
 
+# No sub-initializer is pinned to `NF` — any of them may hold a promoted (e.g. traced) parameter — so
+# `NF` is not derivable from the field types and must be given. `constructorof` rebuilds through this
+# constructor so `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+SoilInitializer{NF}(
+    energy::AbstractInitializer,
+    hydrology::AbstractInitializer,
+    biogeochem::AbstractInitializer,
+) where {NF} = SoilInitializer{NF, typeof(energy), typeof(hydrology), typeof(biogeochem)}(energy, hydrology, biogeochem)
+
+ConstructionBase.constructorof(::Type{<:SoilInitializer{NF}}) where {NF} = SoilInitializer{NF}
+
 function SoilInitializer(
         ::Type{NF};
         energy = QuasiThermalSteadyState(NF),
         hydrology = SaturationWaterTable(NF),
         biogeochem = DefaultInitializer(NF)
     ) where {NF}
-    return SoilInitializer(energy, hydrology, biogeochem)
+    return SoilInitializer{NF}(energy, hydrology, biogeochem)
 end
 
 function initialize!(state, model::AbstractModel, init::SoilInitializer)

--- a/src/models/surface/surface_energy_model.jl
+++ b/src/models/surface/surface_energy_model.jl
@@ -12,8 +12,9 @@ conditions.
         GridType <: AbstractLandGrid{NF},
         SEB <: AbstractSurfaceEnergyBalance,
         Atmosphere <: AbstractAtmosphere,
+        Constants, # <: PhysicalConstants
         Initializer <: AbstractInitializer,
-        Timestepper <: AbstractTimeStepper{NF},
+        Timestepper <: AbstractTimeStepper,
     } <: AbstractSurfaceEnergyModel{NF, GridType}
     "Spatial grid"
     grid::GridType
@@ -25,7 +26,7 @@ conditions.
     @component surface_energy_balance::SEB = SurfaceEnergyBalance(eltype(grid))
 
     "Physical constants"
-    @component constants::PhysicalConstants{NF} = PhysicalConstants(eltype(grid))
+    @component constants::Constants = PhysicalConstants(eltype(grid))
 
     "State variable initializer"
     @component initializer::Initializer = DefaultInitializer(eltype(grid))

--- a/src/models/surface/surface_hydrology_model.jl
+++ b/src/models/surface/surface_hydrology_model.jl
@@ -13,8 +13,9 @@ $TYPEDFIELDS
         CanopyHydrology <: AbstractCanopyInterception,
         CanopyET <: AbstractEvapotranspiration,
         SurfaceRunoff <: AbstractSurfaceRunoff,
+        Constants, # <: PhysicalConstants
         Initializer <: AbstractInitializer,
-        Timestepper <: AbstractTimeStepper{NF},
+        Timestepper <: AbstractTimeStepper,
     } <: AbstractSurfaceHydrologyModel{NF, GridType}
     "Spatial grid type"
     grid::GridType
@@ -32,7 +33,7 @@ $TYPEDFIELDS
     surface_runoff::SurfaceRunoff = DirectSurfaceRunoff(eltype(grid))
 
     "Physical constants"
-    constants::PhysicalConstants{NF} = PhysicalConstants(eltype(grid))
+    constants::Constants = PhysicalConstants(eltype(grid))
 
     "State variable initializer"
     initializer::Initializer = DefaultInitializer(eltype(grid))

--- a/src/models/vegetation/vegetation_model.jl
+++ b/src/models/vegetation/vegetation_model.jl
@@ -10,11 +10,12 @@ $TYPEDFIELDS
 """
 @parameterized @kwdef struct VegetationModel{
         NF,
-        Vegetation <: AbstractVegetation{NF},
-        Atmosphere <: AbstractAtmosphere{NF},
+        Vegetation <: AbstractVegetation,
+        Atmosphere <: AbstractAtmosphere,
         GridType <: AbstractLandGrid{NF},
+        Constants, # <: PhysicalConstants
         Initializer <: AbstractInitializer,
-        Timestepper <: AbstractTimeStepper{NF},
+        Timestepper <: AbstractTimeStepper,
     } <: AbstractVegetationModel{NF, GridType}
     "Spatial grid type"
     grid::GridType
@@ -26,7 +27,7 @@ $TYPEDFIELDS
     @component vegetation::Vegetation = VegetationCarbon(eltype(grid))
 
     "Physical constants"
-    @component constants::PhysicalConstants{NF} = PhysicalConstants(eltype(grid))
+    @component constants::Constants = PhysicalConstants(eltype(grid))
 
     "State variable initializer"
     @component initializer::Initializer = DefaultInitializer(eltype(grid))

--- a/src/processes/atmosphere/abstract_types.jl
+++ b/src/processes/atmosphere/abstract_types.jl
@@ -46,6 +46,6 @@ abstract type AbstractAtmosphere{
     PR <: AbstractPrecipitation,
     IR <: AbstractIncomingRadiation,
     HM <: AbstractHumidity,
-    AD <: AbstractAerodynamics{NF},
+    AD <: AbstractAerodynamics,
 } <: AbstractProcess{NF}
 end

--- a/src/processes/atmosphere/prescribed_atmosphere.jl
+++ b/src/processes/atmosphere/prescribed_atmosphere.jl
@@ -50,7 +50,7 @@ struct PrescribedAtmosphere{
         IncomingRad <: AbstractIncomingRadiation,
         Humidity <: AbstractHumidity,
         Aerodynamics <: AbstractAerodynamics,
-        Gases <: Tuple{Vararg{TracerGas{NF}}},
+        Gases <: Tuple{Vararg{TracerGas}},
     } <: AbstractAtmosphere{NF, Precip, IncomingRad, Humidity, Aerodynamics}
     "Surface-relative altitude in meters at which the atmospheric forcings are assumed to be applied"
     altitude::NF

--- a/src/processes/constants.jl
+++ b/src/processes/constants.jl
@@ -120,7 +120,7 @@ sub-structs by category:
 
 ```jldoctest
 julia> show(PhysicalConstants())
-PhysicalConstants{Float64}(ThermodynamicConstants{Float64}(1004.5, 2070.0, 4181.0, 1859.0, 334000.0, 2.5008e6, 2.8344e6, 273.16, 273.15, 273.16, 611.657, 287.0, 461.5), MaterialConstants{Float64}(1000.0, 916.7, 12.0), UniversalConstants{Float64}(9.80665, 5.6704e-8, 0.4))
+PhysicalConstants{ThermodynamicConstants{Float64}, MaterialConstants{Float64}, UniversalConstants{Float64}}(ThermodynamicConstants{Float64}(1004.5, 2070.0, 4181.0, 1859.0, 334000.0, 2.5008e6, 2.8344e6, 273.16, 273.15, 273.16, 611.657, 287.0, 461.5), MaterialConstants{Float64}(1000.0, 916.7, 12.0), UniversalConstants{Float64}(9.80665, 5.6704e-8, 0.4))
 ```
 
 To override individual constants, pass a customised sub-struct:
@@ -137,19 +137,23 @@ julia> c.thermodynamics.temperature_reference
 Properties:
 $FIELDS
 """
-struct PhysicalConstants{NF}
-    thermodynamics::ThermodynamicConstants{NF}
-    material::MaterialConstants{NF}
-    universal::UniversalConstants{NF}
+struct PhysicalConstants{
+        Thermo,    # <: ThermodynamicConstants
+        Material,  # <: MaterialConstants
+        Universal, # <: UniversalConstants
+    }
+    thermodynamics::Thermo
+    material::Material
+    universal::Universal
 end
 
 PhysicalConstants() = PhysicalConstants(Float64)
 
 function PhysicalConstants(
         ::Type{NF};
-        thermodynamics::ThermodynamicConstants{NF} = ThermodynamicConstants(NF),
-        material::MaterialConstants{NF} = MaterialConstants(NF),
-        universal::UniversalConstants{NF} = UniversalConstants(NF),
+        thermodynamics::ThermodynamicConstants = ThermodynamicConstants(NF),
+        material::MaterialConstants = MaterialConstants(NF),
+        universal::UniversalConstants = UniversalConstants(NF),
     ) where {NF}
-    return PhysicalConstants{NF}(thermodynamics, material, universal)
+    return PhysicalConstants(thermodynamics, material, universal)
 end

--- a/src/processes/soil/energy/soil_energy.jl
+++ b/src/processes/soil/energy/soil_energy.jl
@@ -24,6 +24,12 @@ struct SoilThermodynamics{
     thermal_properties::ThermalProps
 end
 
+SoilThermodynamics{NF}(
+    operator::AbstractHeatOperator,
+    closure::AbstractEnergyClosure,
+    thermal_properties::SoilThermalProperties,
+) where {NF} = SoilThermodynamics{NF, typeof(operator), typeof(closure), typeof(thermal_properties)}(operator, closure, thermal_properties)
+
 SoilThermodynamics(
     ::Type{NF};
     operator::AbstractHeatOperator = ExplicitTwoPhaseHeatConduction(),

--- a/src/processes/soil/energy/soil_energy.jl
+++ b/src/processes/soil/energy/soil_energy.jl
@@ -12,7 +12,7 @@ struct SoilThermodynamics{
         NF,
         HeatOperator <: AbstractHeatOperator,
         EnergyClosure <: AbstractEnergyClosure,
-        ThermalProps <: SoilThermalProperties{NF},
+        ThermalProps <: SoilThermalProperties,
     } <: AbstractSoilThermodynamics{NF}
     "Heat transport operator"
     operator::HeatOperator
@@ -28,11 +28,21 @@ SoilThermodynamics(
     ::Type{NF};
     operator::AbstractHeatOperator = ExplicitTwoPhaseHeatConduction(),
     closure::AbstractEnergyClosure = SoilEnergyTemperatureClosure(),
-    thermal_properties::SoilThermalProperties{NF} = SoilThermalProperties(NF),
-) where {NF} = SoilThermodynamics(operator, closure, thermal_properties)
+    thermal_properties::SoilThermalProperties = SoilThermalProperties(NF),
+) where {NF} = SoilThermodynamics{NF, typeof(operator), typeof(closure), typeof(thermal_properties)}(operator, closure, thermal_properties)
+
+# Retain `NF` when rebuilding from properties (`setproperties`, `Flatten.reconstruct`,
+# `ParameterEditing.reconstruct`); the default `constructorof` would drop it.
+ConstructionBase.constructorof(::Type{<:SoilThermodynamics{NF}}) where {NF} = SoilThermodynamics{NF}
 
 # TODO: Add base `AbstractParameterization` type and then (hopefully) remove
-Adapt.@adapt_structure SoilThermodynamics
+# Written out rather than `Adapt.@adapt_structure` because that macro rebuilds via the bare type
+# name, which cannot recover `NF`.
+Adapt.adapt_structure(to, energy::SoilThermodynamics{NF}) where {NF} = SoilThermodynamics{NF}(
+    adapt(to, energy.operator),
+    adapt(to, energy.closure),
+    adapt(to, energy.thermal_properties),
+)
 
 variables(energy::SoilThermodynamics) = (
     prognostic(:internal_energy, XYZ(); closure = energy.closure, units = u"J/m^3", desc = "Internal energy of the soil volume, including both latent and sensible components"),

--- a/src/processes/soil/energy/soil_thermal_properties.jl
+++ b/src/processes/soil/energy/soil_thermal_properties.jl
@@ -65,11 +65,12 @@ SoilHeatCapacities(::Type{NF}; kwargs...) where {NF} = SoilHeatCapacities{NF}(; 
 Properties:
 $TYPEDFIELDS
 """
-@parameterized @kwdef struct SoilThermalProperties{ 
-    Cond,       # <: SoilThermalConductivities
-    CondWeight, # <: AbstractBulkWeighting
-    SoilHeatC,  # <: SoilHeatCapacities
-    FC}         # <: FreezeCurve
+@parameterized @kwdef struct SoilThermalProperties{
+        Cond,       # <: SoilThermalConductivities
+        CondWeight, # <: AbstractBulkWeighting
+        SoilHeatC,  # <: SoilHeatCapacities
+        FC,
+    }         # <: FreezeCurve
     "Thermal conductivities for all constituents"
     @component conductivities::Cond
 
@@ -87,7 +88,7 @@ SoilThermalProperties(
     ::Type{NF};
     conductivities::SoilThermalConductivities = SoilThermalConductivities(NF),
     conductivity_weighting::AbstractBulkWeighting = InverseQuadratic(),
-    heat_capacities::SoilHeatCapacities{NF} = SoilHeatCapacities(NF),
+    heat_capacities::SoilHeatCapacities = SoilHeatCapacities(NF),
     freezecurve::FreezeCurve = FreeWater()
 ) where {NF} = SoilThermalProperties(conductivities, conductivity_weighting, heat_capacities, freezecurve)
 

--- a/src/processes/soil/energy/soil_thermal_properties.jl
+++ b/src/processes/soil/energy/soil_thermal_properties.jl
@@ -65,7 +65,11 @@ SoilHeatCapacities(::Type{NF}; kwargs...) where {NF} = SoilHeatCapacities{NF}(; 
 Properties:
 $TYPEDFIELDS
 """
-@parameterized @kwdef struct SoilThermalProperties{NF, FC, CondWeight, Cond}
+@parameterized @kwdef struct SoilThermalProperties{ 
+    Cond,       # <: SoilThermalConductivities
+    CondWeight, # <: AbstractBulkWeighting
+    SoilHeatC,  # <: SoilHeatCapacities
+    FC}         # <: FreezeCurve
     "Thermal conductivities for all constituents"
     @component conductivities::Cond
 
@@ -73,7 +77,7 @@ $TYPEDFIELDS
     @component conductivity_weighting::CondWeight
 
     "Thermal conductivities for all constituents"
-    @component heat_capacities::SoilHeatCapacities{NF}
+    @component heat_capacities::SoilHeatC
 
     "Freezing characteristic curve needed for energy-temperature closure"
     @component freezecurve::FC
@@ -85,14 +89,14 @@ SoilThermalProperties(
     conductivity_weighting::AbstractBulkWeighting = InverseQuadratic(),
     heat_capacities::SoilHeatCapacities{NF} = SoilHeatCapacities(NF),
     freezecurve::FreezeCurve = FreeWater()
-) where {NF} = SoilThermalProperties{NF, typeof(freezecurve), typeof(conductivity_weighting), typeof(conductivities)}(conductivities, conductivity_weighting, heat_capacities, freezecurve)
+) where {NF} = SoilThermalProperties(conductivities, conductivity_weighting, heat_capacities, freezecurve)
 
 Adapt.@adapt_structure SoilThermalProperties
 
 freezecurve(
-    ::SoilThermalProperties{NF, FreeWater},
+    ::SoilThermalProperties{<:Any, <:Any, <:Any, FreeWater},
     ::AbstractSoilHydrology
-) where {NF} = FreeWater()
+) = FreeWater()
 
 """
     $SIGNATURES

--- a/src/processes/soil/hydrology/soil_hydraulic_properties.jl
+++ b/src/processes/soil/hydrology/soil_hydraulic_properties.jl
@@ -70,7 +70,7 @@ measurements of hydraulic properites are available.
 Properties:
 $TYPEDFIELDS
 """
-@parameterized @kwdef struct ConstantSoilHydraulics{NF, RC, UnsatK <: AbstractUnsatK{NF}} <: AbstractSoilHydraulics{NF, RC, UnsatK}
+@parameterized @kwdef struct ConstantSoilHydraulics{NF, RC, UnsatK <: AbstractUnsatK} <: AbstractSoilHydraulics{NF, RC, UnsatK}
     "Soil water retention curve"
     @component swrc::RC
 
@@ -121,7 +121,7 @@ $TYPEDFIELDS
 
 * [noilhanISBA1996](@cite) Noilhan & Mahfouf, Global and Planetary Change (1996)
 """
-@parameterized @kwdef struct SoilHydraulicsSURFEX{NF, RC, UnsatK <: AbstractUnsatK{NF}} <: AbstractSoilHydraulics{NF, RC, UnsatK}
+@parameterized @kwdef struct SoilHydraulicsSURFEX{NF, RC, UnsatK <: AbstractUnsatK} <: AbstractSoilHydraulics{NF, RC, UnsatK}
     "Soil water retention curve"
     @component swrc::RC
 

--- a/src/processes/soil/hydrology/soil_hydrology.jl
+++ b/src/processes/soil/hydrology/soil_hydrology.jl
@@ -22,7 +22,7 @@ struct SoilHydrology{
         NF,
         VerticalFlow <: AbstractVerticalFlow,
         SaturationClosure <: AbstractSoilWaterClosure,
-        SoilHydraulics <: AbstractSoilHydraulics{NF},
+        SoilHydraulics <: AbstractSoilHydraulics,
         VWCForcing <: Union{Nothing, AbstractForcing},
     } <: AbstractSoilHydrology{NF}
     "Soil water vertical flow operator"
@@ -38,6 +38,20 @@ struct SoilHydrology{
     vwc_forcing::VWCForcing
 end
 
+# `hydraulic_properties` is not pinned to `NF` — it may hold a promoted (e.g. traced) parameter — so
+# `NF` is not derivable from the field types and must be given. `constructorof` rebuilds through this
+# constructor so `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+SoilHydrology{NF}(
+    vertical_flow::AbstractVerticalFlow,
+    closure::AbstractSoilWaterClosure,
+    hydraulic_properties::AbstractSoilHydraulics,
+    vwc_forcing::Union{Nothing, AbstractForcing},
+) where {NF} = SoilHydrology{NF, typeof(vertical_flow), typeof(closure), typeof(hydraulic_properties), typeof(vwc_forcing)}(
+    vertical_flow, closure, hydraulic_properties, vwc_forcing
+)
+
+ConstructionBase.constructorof(::Type{<:SoilHydrology{NF}}) where {NF} = SoilHydrology{NF}
+
 function SoilHydrology(
         ::Type{NF};
         vertical_flow::AbstractVerticalFlow = NoFlow(),
@@ -45,7 +59,7 @@ function SoilHydrology(
         hydraulic_properties::AbstractSoilHydraulics = SoilHydraulicsSURFEX(NF),
         vwc_forcing::Union{Nothing, AbstractForcing} = nothing,
     ) where {NF}
-    return SoilHydrology(vertical_flow, closure, hydraulic_properties, vwc_forcing)
+    return SoilHydrology{NF}(vertical_flow, closure, hydraulic_properties, vwc_forcing)
 end
 
 function SoilHydrology(::Type{NF}, vertical_flow::AbstractVerticalFlow; kwargs...) where {NF}

--- a/src/processes/soil/soil_coupled.jl
+++ b/src/processes/soil/soil_coupled.jl
@@ -6,10 +6,10 @@ The stratigraphy parameterization determines how the vertical layering of the so
 """
 struct SoilEnergyWaterCarbon{
         NF,
-        Stratigraphy <: AbstractStratigraphy{NF},
-        Energy <: AbstractSoilThermodynamics{NF},
-        Hydrology <: AbstractSoilHydrology{NF},
-        Biogeochemistry <: AbstractSoilBiogeochemistry{NF},
+        Stratigraphy <: AbstractStratigraphy,
+        Energy <: AbstractSoilThermodynamics,
+        Hydrology <: AbstractSoilHydrology,
+        Biogeochemistry <: AbstractSoilBiogeochemistry,
     } <: AbstractSoil{NF}
     "Soil stratigraphy parameterization"
     strat::Stratigraphy
@@ -24,6 +24,20 @@ struct SoilEnergyWaterCarbon{
     biogeochem::Biogeochemistry
 end
 
+# No component is pinned to `NF` — any of them may hold a promoted (e.g. traced) parameter — so `NF`
+# is not derivable from the field types and must be given. `constructorof` rebuilds through this
+# constructor so `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+SoilEnergyWaterCarbon{NF}(
+    strat::AbstractStratigraphy,
+    energy::AbstractSoilThermodynamics,
+    hydrology::AbstractSoilHydrology,
+    biogeochem::AbstractSoilBiogeochemistry,
+) where {NF} = SoilEnergyWaterCarbon{NF, typeof(strat), typeof(energy), typeof(hydrology), typeof(biogeochem)}(
+    strat, energy, hydrology, biogeochem
+)
+
+ConstructionBase.constructorof(::Type{<:SoilEnergyWaterCarbon{NF}}) where {NF} = SoilEnergyWaterCarbon{NF}
+
 function SoilEnergyWaterCarbon(
         ::Type{NF};
         strat = HomogeneousSoilStratigraphy(NF),
@@ -31,7 +45,7 @@ function SoilEnergyWaterCarbon(
         hydrology = SoilHydrology(NF),
         biogeochem = ConstantSoilCarbonDensity(NF)
     ) where {NF}
-    return SoilEnergyWaterCarbon(strat, energy, hydrology, biogeochem)
+    return SoilEnergyWaterCarbon{NF}(strat, energy, hydrology, biogeochem)
 end
 
 # Process interface methods

--- a/src/processes/soil/stratigraphy/soil_composition.jl
+++ b/src/processes/soil/stratigraphy/soil_composition.jl
@@ -8,7 +8,7 @@ and a mixture of organic and mineral solid material.
 Properties:
 $FIELDS
 """
-struct SoilComposition{NF, Solid <: AbstractSoilMatrix{NF}}
+struct SoilComposition{NF, Solid <: AbstractSoilMatrix}
     "Natural porosity or void space of the soil"
     porosity::NF
 
@@ -21,7 +21,7 @@ struct SoilComposition{NF, Solid <: AbstractSoilMatrix{NF}}
     "Parameterization of the solid phase (matrix) of the soil"
     solid::Solid
 
-    function SoilComposition(porosity::NF, saturation::NF, liquid::NF, solid::AbstractSoilMatrix{NF}) where {NF <: Number}
+    function SoilComposition(porosity::NF, saturation::NF, liquid::NF, solid::AbstractSoilMatrix) where {NF <: Number}
         return new{NF, typeof(solid)}(porosity, saturation, liquid, solid)
     end
 end
@@ -90,15 +90,15 @@ Soil matrix consisting of a simple, homogeneous mixture of mineral and organic m
 Properties:
 $TYPEDFIELDS
 """
-struct MineralOrganic{NF} <: AbstractSoilMatrix{NF}
+struct MineralOrganic{NF, Texture} <: AbstractSoilMatrix{NF}
     "Mineral soil texture"
-    texture::SoilTexture{NF}
+    texture::Texture
 
     "Organic soil fraction"
     organic::NF
 
-    function MineralOrganic(texture::SoilTexture{NF}, organic::NF) where {NF}
-        return new{NF}(texture, organic)
+    function MineralOrganic(texture::SoilTexture, organic::NF) where {NF}
+        return new{NF, typeof(texture)}(texture, organic)
     end
 end
 
@@ -114,9 +114,9 @@ function MineralOrganic(; texture = SoilTexture(), organic = zero(eltype(texture
 end
 
 """
-Alias for `SoilComposition{T, MineralOrganic{T}}`
+Alias for `SoilComposition{NF, <:MineralOrganic{NF}}`
 """
-const MineralOrganicSoil{NF} = SoilComposition{NF, MineralOrganic{NF}}
+const MineralOrganicSoil{NF} = SoilComposition{NF, <:MineralOrganic{NF}}
 
 @inline mineral_texture(solid::MineralOrganic) = solid.texture
 

--- a/src/processes/soil/stratigraphy/soil_horizon.jl
+++ b/src/processes/soil/stratigraphy/soil_horizon.jl
@@ -4,18 +4,23 @@
 Represents an arbitrary soil horizon whose properties (texture and porosity) are assumed to
 be constant across both space and time.
 """
-@parameterized struct ConstantSoilHorizon{NF, name, Porosity <: AbstractSoilPorosity{NF}} <: AbstractSoilHorizon{NF, name}
+@parameterized struct ConstantSoilHorizon{
+        NF,
+        name,
+        Porosity <: AbstractSoilPorosity,
+        Texture, # <: SoilTexture
+    } <: AbstractSoilHorizon{NF, name}
     "Parameterization of soil porosity"
     @component porosity::Porosity
 
     "Material composition of mineral soil component"
-    @component texture::SoilTexture{NF}
+    @component texture::Texture
 
     "Thickness of the soil horizon in meters"
     @param thickness::NF
 
     function ConstantSoilHorizon(name::Symbol, texture::SoilTexture, porosity::AbstractSoilPorosity, thickness::NF) where {NF}
-        return new{NF, name, typeof(porosity)}(porosity, texture, thickness)
+        return new{NF, name, typeof(porosity), typeof(texture)}(porosity, texture, thickness)
     end
 end
 
@@ -38,14 +43,14 @@ end
 Represents an arbitrary soil horizon whose properties (texture and porosity) are prescribed
 via input `Field`s and can therefore vary across space and (less commonly) time.
 """
-@parameterized struct PrescribedSoilHorizon{NF, name, Porosity <: AbstractSoilPorosity{NF}} <: AbstractSoilHorizon{NF, name}
+@parameterized struct PrescribedSoilHorizon{NF, name, Porosity <: AbstractSoilPorosity} <: AbstractSoilHorizon{NF, name}
     "Parameterization of soil porosity"
     @component porosity::Porosity
 
     "Default horizon thickness applied uniformly to all grid cells"
     default_thickness::NF
 
-    function PrescribedSoilHorizon(name::Symbol, porosity::AbstractSoilPorosity{NF}, default_thickness::NF) where {NF}
+    function PrescribedSoilHorizon(name::Symbol, porosity::AbstractSoilPorosity, default_thickness::NF) where {NF}
         return new{NF, name, typeof(porosity)}(porosity, default_thickness)
     end
 end

--- a/src/processes/soil/stratigraphy/soil_stratigraphy.jl
+++ b/src/processes/soil/stratigraphy/soil_stratigraphy.jl
@@ -8,14 +8,22 @@ respective names are defined by the user.
 Properties:
 $TYPEDFIELDS
 """
-struct SoilStratigraphy{NF, N, Horizons <: Tuple{Vararg{AbstractSoilHorizon{NF}, N}}} <: AbstractStratigraphy{NF}
+struct SoilStratigraphy{NF, N, Horizons <: Tuple{Vararg{AbstractSoilHorizon, N}}} <: AbstractStratigraphy{NF}
     "Named tuple of soil horizons ordered from top to bottom"
     horizons::Horizons
 end
 
+# The horizons are not pinned to `NF` — any of their parameters may be promoted (e.g. traced) — so
+# `NF` is not derivable from the field types and must be given. `constructorof` rebuilds through
+# this constructor so `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+SoilStratigraphy{NF}(horizons::Tuple{Vararg{AbstractSoilHorizon, N}}) where {NF, N} =
+    SoilStratigraphy{NF, N, typeof(horizons)}(horizons)
+
+ConstructionBase.constructorof(::Type{<:SoilStratigraphy{NF}}) where {NF} = SoilStratigraphy{NF}
+
 function SoilStratigraphy(::Type{NF}, horizons::AbstractSoilHorizon...) where {NF}
     @assert length(horizons) > 0 "At least one soil horizon must be specified; for simple configurations, consider using HomogeneousSoilStratigraphy."
-    return SoilStratigraphy(horizons)
+    return SoilStratigraphy{NF}(horizons)
 end
 
 # Convenience constructors
@@ -51,7 +59,7 @@ function SoilGridsStratigraphy(
         horizon5::AbstractSoilHorizon = PrescribedSoilHorizon(NF, :horizon5; porosity, default_thickness = NF(0.4)),
         horizon6::AbstractSoilHorizon = PrescribedSoilHorizon(NF, :horizon6; porosity, default_thickness = NF(1.0))
     ) where {NF}
-    return SoilStratigraphy((horizon1, horizon2, horizon3, horizon4, horizon5, horizon6))
+    return SoilStratigraphy{NF}((horizon1, horizon2, horizon3, horizon4, horizon5, horizon6))
 end
 
 # Base methods

--- a/src/processes/surface/surface_energy_balance.jl
+++ b/src/processes/surface/surface_energy_balance.jl
@@ -8,10 +8,10 @@ as well as the albedo.
 """
 struct SurfaceEnergyBalance{
         NF,
-        SkinTemperature <: AbstractSkinTemperature{NF},
-        TurbulentFluxes <: AbstractTurbulentFluxes{NF},
-        RadiativeFluxes <: AbstractRadiativeFluxes{NF},
-        Albedo <: AbstractAlbedo{NF},
+        SkinTemperature <: AbstractSkinTemperature,
+        RadiativeFluxes <: AbstractRadiativeFluxes,
+        TurbulentFluxes <: AbstractTurbulentFluxes,
+        Albedo <: AbstractAlbedo,
     } <: AbstractSurfaceEnergyBalance{NF}
     "Scheme for determining skin temperature and ground heat flux"
     skin_temperature::SkinTemperature
@@ -26,6 +26,20 @@ struct SurfaceEnergyBalance{
     albedo::Albedo
 end
 
+# No sub-scheme is pinned to `NF` — any of them may hold a promoted (e.g. traced) parameter — so `NF`
+# is not derivable from the field types and must be given. `constructorof` rebuilds through this
+# constructor so `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+SurfaceEnergyBalance{NF}(
+    skin_temperature::AbstractSkinTemperature,
+    radiative_fluxes::AbstractRadiativeFluxes,
+    turbulent_fluxes::AbstractTurbulentFluxes,
+    albedo::AbstractAlbedo,
+) where {NF} = SurfaceEnergyBalance{NF, typeof(skin_temperature), typeof(radiative_fluxes), typeof(turbulent_fluxes), typeof(albedo)}(
+    skin_temperature, radiative_fluxes, turbulent_fluxes, albedo
+)
+
+ConstructionBase.constructorof(::Type{<:SurfaceEnergyBalance{NF}}) where {NF} = SurfaceEnergyBalance{NF}
+
 function SurfaceEnergyBalance(
         ::Type{NF};
         radiative_fluxes::AbstractRadiativeFluxes = DiagnosedRadiativeFluxes(NF),
@@ -33,7 +47,7 @@ function SurfaceEnergyBalance(
         skin_temperature::AbstractSkinTemperature = ImplicitSkinTemperature(NF),
         albedo::AbstractAlbedo = ConstantAlbedo(NF)
     ) where {NF}
-    return SurfaceEnergyBalance(skin_temperature, radiative_fluxes, turbulent_fluxes, albedo)
+    return SurfaceEnergyBalance{NF}(skin_temperature, radiative_fluxes, turbulent_fluxes, albedo)
 end
 
 variables(seb::SurfaceEnergyBalance) = tuplejoin(

--- a/src/processes/surface/surface_hydrology.jl
+++ b/src/processes/surface/surface_hydrology.jl
@@ -9,9 +9,9 @@ $FIELDS
 """
 struct SurfaceHydrology{
         NF,
-        CanopyInterception <: AbstractCanopyInterception{NF},
-        Evapotranspiration <: AbstractEvapotranspiration{NF},
-        SurfaceRunoff <: AbstractSurfaceRunoff{NF},
+        CanopyInterception <: AbstractCanopyInterception,
+        Evapotranspiration <: AbstractEvapotranspiration,
+        SurfaceRunoff <: AbstractSurfaceRunoff,
     } <: AbstractSurfaceHydrology{NF}
     "Canopy hydrology scheme"
     canopy_interception::CanopyInterception
@@ -23,13 +23,26 @@ struct SurfaceHydrology{
     surface_runoff::SurfaceRunoff
 end
 
+# No sub-scheme is pinned to `NF` — any of them may hold a promoted (e.g. traced) parameter — so `NF`
+# is not derivable from the field types and must be given. `constructorof` rebuilds through this
+# constructor so `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+SurfaceHydrology{NF}(
+    canopy_interception::AbstractCanopyInterception,
+    evapotranspiration::AbstractEvapotranspiration,
+    surface_runoff::AbstractSurfaceRunoff,
+) where {NF} = SurfaceHydrology{NF, typeof(canopy_interception), typeof(evapotranspiration), typeof(surface_runoff)}(
+    canopy_interception, evapotranspiration, surface_runoff
+)
+
+ConstructionBase.constructorof(::Type{<:SurfaceHydrology{NF}}) where {NF} = SurfaceHydrology{NF}
+
 function SurfaceHydrology(
         ::Type{NF};
-        canopy_interception::CI = PALADYNCanopyInterception(NF),
-        evapotranspiration::ET = PALADYNCanopyEvapotranspiration(NF),
-        surface_runoff::SR = DirectSurfaceRunoff(NF)
-    ) where {NF, CI, ET, SR}
-    return SurfaceHydrology{NF, CI, ET, SR}(canopy_interception, evapotranspiration, surface_runoff)
+        canopy_interception::AbstractCanopyInterception = PALADYNCanopyInterception(NF),
+        evapotranspiration::AbstractEvapotranspiration = PALADYNCanopyEvapotranspiration(NF),
+        surface_runoff::AbstractSurfaceRunoff = DirectSurfaceRunoff(NF)
+    ) where {NF}
+    return SurfaceHydrology{NF}(canopy_interception, evapotranspiration, surface_runoff)
 end
 
 """ $TYPEDSIGNATURES """

--- a/src/processes/vegetation/vegetation_carbon.jl
+++ b/src/processes/vegetation/vegetation_carbon.jl
@@ -5,11 +5,11 @@ Represents a generic coupling of vegetation carbon processes.
 """
 @kwdef struct VegetationCarbon{
         NF,
-        Photosynthesis <: AbstractPhotosynthesis{NF},
-        StomatalConductance <: AbstractStomatalConductance{NF},
-        AutotrophicRespiration <: AbstractAutotrophicRespiration{NF},
-        Phenology <: AbstractPhenology{NF},
-        CarbonDynamics <: AbstractVegetationCarbonDynamics{NF},
+        Photosynthesis <: AbstractPhotosynthesis,
+        StomatalConductance <: AbstractStomatalConductance,
+        AutotrophicRespiration <: AbstractAutotrophicRespiration,
+        Phenology <: AbstractPhenology,
+        CarbonDynamics <: AbstractVegetationCarbonDynamics,
         VegetationDynamics <: Optional{AbstractVegetationDynamics},
         RootDistribution <: Optional{AbstractRootDistribution},
         PAW <: Optional{AbstractPlantAvailableWater},
@@ -39,6 +39,41 @@ Represents a generic coupling of vegetation carbon processes.
     plant_available_water::PAW
 end
 
+# No component process is pinned to `NF` — any of them may hold a promoted (e.g. traced) parameter —
+# so `NF` is not derivable from the field types and must be given. `constructorof` rebuilds through
+# this constructor so `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+VegetationCarbon{NF}(
+    photosynthesis::AbstractPhotosynthesis,
+    stomatal_conductance::AbstractStomatalConductance,
+    autotrophic_respiration::AbstractAutotrophicRespiration,
+    phenology::AbstractPhenology,
+    carbon_dynamics::AbstractVegetationCarbonDynamics,
+    vegetation_dynamics::Optional{AbstractVegetationDynamics},
+    root_distribution::Optional{AbstractRootDistribution},
+    plant_available_water::Optional{AbstractPlantAvailableWater},
+) where {NF} = VegetationCarbon{
+    NF,
+    typeof(photosynthesis),
+    typeof(stomatal_conductance),
+    typeof(autotrophic_respiration),
+    typeof(phenology),
+    typeof(carbon_dynamics),
+    typeof(vegetation_dynamics),
+    typeof(root_distribution),
+    typeof(plant_available_water),
+}(
+    photosynthesis,
+    stomatal_conductance,
+    autotrophic_respiration,
+    phenology,
+    carbon_dynamics,
+    vegetation_dynamics,
+    root_distribution,
+    plant_available_water,
+)
+
+ConstructionBase.constructorof(::Type{<:VegetationCarbon{NF}}) where {NF} = VegetationCarbon{NF}
+
 function VegetationCarbon(
         ::Type{NF};
         photosynthesis = LUEPhotosynthesis(NF),
@@ -50,7 +85,7 @@ function VegetationCarbon(
         root_distribution = StaticExponentialRootDistribution(NF),
         plant_available_water = FieldCapacityLimitedPAW(NF)
     ) where {NF}
-    return VegetationCarbon(;
+    return VegetationCarbon{NF}(
         photosynthesis,
         stomatal_conductance,
         autotrophic_respiration,

--- a/src/solvers/root_solvers.jl
+++ b/src/solvers/root_solvers.jl
@@ -3,7 +3,7 @@
 
 Wrapper for RootSolvers.jl root-finding methods.
 """
-struct RootSolver{NF, M, S, Tolerance <: RootSolvers.AbstractTolerance{NF}}
+struct RootSolver{NF, M, S, Tolerance <: RootSolvers.AbstractTolerance}
     "Numerical tolerance of the root finding iteration"
     tolerance::Tolerance
 

--- a/src/timesteppers/imex.jl
+++ b/src/timesteppers/imex.jl
@@ -42,8 +42,8 @@ $(TYPEDFIELDS)
 """
 struct IMEX{
         NF,
-        E <: AbstractTimeStepper{NF},
-        I <: AbstractTimeStepper{NF},
+        E <: AbstractTimeStepper,
+        I <: AbstractTimeStepper,
     } <: AbstractIMEX{NF}
     "Sub-stepper for prognostic variables of class `Explicit` (should have `timestepping(explicit) == Explicit()`)"
     explicit::E
@@ -56,11 +56,23 @@ end
     IMEX(explicit, implicit)
     IMEX(; explicit, implicit)
 
-Construct an [`IMEX`](@ref) time stepper from an `explicit` and an `implicit` sub-stepper (which must share
-the same numerical type `NF`). Which prognostic variables are integrated implicitly is controlled by
+Construct an [`IMEX`](@ref) time stepper from an `explicit` and an `implicit` sub-stepper. The sub-steppers
+need not share a number format; the `IMEX`'s own `NF` is taken from `explicit` unless given explicitly as
+`IMEX{NF}(explicit, implicit)`. Which prognostic variables are integrated implicitly is controlled by
 specializing [`timestepping`](@ref).
 """
 IMEX(; explicit, implicit) = IMEX(explicit, implicit)
+
+# Neither sub-stepper is pinned to `NF` — either may hold a promoted (e.g. traced) timestep — so `NF`
+# is not derivable from the field types. It defaults to the explicit sub-stepper's number format, or
+# can be given as `IMEX{NF}(explicit, implicit)`. `constructorof` rebuilds through this constructor so
+# `setproperties` / `Flatten.reconstruct` / `Adapt` retain `NF`.
+IMEX{NF}(explicit::AbstractTimeStepper, implicit::AbstractTimeStepper) where {NF} =
+    IMEX{NF, typeof(explicit), typeof(implicit)}(explicit, implicit)
+
+IMEX(explicit::AbstractTimeStepper{NF}, implicit::AbstractTimeStepper) where {NF} = IMEX{NF}(explicit, implicit)
+
+ConstructionBase.constructorof(::Type{<:IMEX{NF}}) where {NF} = IMEX{NF}
 
 default_dt(imex::AbstractIMEX) = default_dt(explicit_timestepper(imex))
 
@@ -79,8 +91,8 @@ $(TYPEDFIELDS)
 struct IMEXCache{
         classes,
         NF,
-        EC <: AbstractTimeStepperCache{NF},
-        IC <: AbstractTimeStepperCache{NF},
+        EC <: AbstractTimeStepperCache,
+        IC <: AbstractTimeStepperCache,
     } <: AbstractTimeStepperCache{NF}
     "Cache for the explicit sub-stepper"
     explicit::EC
@@ -89,8 +101,9 @@ struct IMEXCache{
     implicit::IC
 end
 
-# Construct an IMEXCache with the resolved `classes` given as the leading type parameter.
-function IMEXCache{classes}(explicit::EC, implicit::IC) where {classes, NF, EC <: AbstractTimeStepperCache{NF}, IC <: AbstractTimeStepperCache{NF}}
+# Construct an IMEXCache with the resolved `classes` given as the leading type parameter; `NF` is
+# taken from the explicit sub-cache since the sub-caches are not pinned to a common `NF`.
+function IMEXCache{classes}(explicit::EC, implicit::IC) where {classes, NF, EC <: AbstractTimeStepperCache{NF}, IC <: AbstractTimeStepperCache}
     return IMEXCache{classes, NF, EC, IC}(explicit, implicit)
 end
 

--- a/src/timesteppers/model_integrator.jl
+++ b/src/timesteppers/model_integrator.jl
@@ -11,7 +11,7 @@ struct ModelIntegrator{
         NF,
         Arch <: AbstractArchitecture,
         Grid <: AbstractLandGrid{NF, Arch},
-        TimeStepper <: AbstractTimeStepper{NF},
+        TimeStepper <: AbstractTimeStepper,
         Model <: AbstractModel{NF, Grid},
         StateVars <: AbstractStateVariables,
         ClockType <: Clock,


### PR DESCRIPTION
This came up in #59 and is needed to deal with the fact that Reactant might replace individual `NF` with traced versions of it. 

Should we also directly address the `AbstractParameterzation` and `@adapt_structure` here, @bgroenks96 ?