### PR TITLE
Rework handling of snow-ground interface in surface energy balance

### DIFF
--- a/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
+++ b/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
@@ -1,0 +1,188 @@
+# Investigation: insufficient high-latitude winter snow accumulation (SEB/snow-fraction coupling)
+
+> Status: **planned**. Investigation + candidate fixes for the reported bug (SWE < 0.001 m at northern
+> latitudes in winter, likely from excessive melt).
+
+Date of initial draft: 2026-08-27
+
+Base revision: 836bbb44b2e04c8e2ff0882be7d61ae1d2e6094f
+
+## Originating prompt
+
+> There currently appears to be a bug where not enough snow is accumulating in the northern latitudes
+> during winter (<0.001 m SWE), likely due to it being melted too fast. Please review the current
+> implementation as well as the text from the GitHub issue [pasted below] and prepare a plan for an
+> investigation + potential fixes.
+
+GitHub issue (verbatim, condensed): the surface energy balance (SEB) uses `ground_heat_flux` to force
+the top of the snowpack. With fractional snow cover and no tiling, the SEB blends ground/snow inputs
+(temperature, conductivity) into a single bulk `ground_heat_flux`, which is then applied unmediated as
+the snowpack's top boundary flux. This likely produces unrealistic snow-top fluxes. The ideal fix is
+tiling (solve the SEB separately for snow-covered and snow-free fractions); an interim alternative is to
+force the *actual ground* with `ground_heat_flux` and partition it in the SEB into `G_g` (snow-free
+conductive flux) and `G_s` (snow-covered conductive flux):
+`R_net(Ts) + H(Ts) + LE(Ts) - G_g(Ts) - G_s(Ts) = 0`. A remaining concern even under partitioning: the
+skin temperature is still solved with a single aggregated albedo in `R_net`, so the snow-covered fraction
+still sees an unrealistic radiation budget.
+
+## Revision log
+
+- Rev 1 (2026-08-27): initial draft from code review of `skin_temperature.jl`, `surface_energy_balance.jl`,
+  `snow_energy.jl`, `snow_interfaces.jl`, `albedo.jl`, and `land_model.jl`.
+
+## Problem description
+
+Northern-latitude winter SWE stays below 0.001 m — snow that does accumulate appears to melt (or
+sublimate/never accumulate) almost immediately, rather than persisting through the cold season.
+
+## Background: how the bulk-blend forcing actually reaches the snowpack today
+
+Confirmed by reading the current implementation (not yet run/instrumented):
+
+1. **Skin temperature solve blends the conduction target, not just diagnostics.**
+   [`ground_thermal_interface`](../../src/processes/surface/skin_temperature.jl#L121-L132) (snow-aware
+   overload) computes `Tg_eff = (1-f)·T_ground + f·T_snow`, `κ_eff = (1-f)·κₛ + f·κ_snow`,
+   `Δz_eff = (1-f)·Δz_ground + f·d_snow`, and the implicit solve uses these to get
+   `Ts = Tg_eff - G·Δz_eff/(2·κ_eff)` ([`skin_temperature.jl:94-97`](../../src/processes/surface/skin_temperature.jl#L94-L97)).
+   `G` itself closes the SEB as `G = R_net(Ts) + H_s(Ts) + H_l(Ts)`
+   ([`skin_temperature.jl:141-144`](../../src/processes/surface/skin_temperature.jl#L141-L144)). So there is
+   a *single* skin temperature and a *single* bulk `G` for the whole grid cell, exactly as the issue
+   describes — this is not tiled.
+2. **That same bulk `G` is fed directly into the snowpack's top-of-pack energy tendency, unmediated by
+   `f_snow`.** In `LandModel`, `snow_flux_aliases = (; surface_heat_flux = ground_heat_flux, ...)`
+   ([`land_model.jl:81`](../../src/models/coupled/land_model.jl#L81)) — no `f_snow` weighting at all — and
+   [`compute_snow_energy_tendency`](../../src/processes/snow/energy/snow_energy.jl#L79-L100) reads
+   `Q_top = fields.surface_heat_flux[i,j]` directly as `dŪ_snow/dt = Q_base - Q_top + ...`. So a grid cell
+   with, say, `f_snow = 0.1` still has the *entire* bulk `G` (computed from a 90%-bare-ground-weighted
+   conduction target and a blended albedo) driving 100% of the snowpack's top-of-pack tendency. This is
+   the mechanism most directly implicated by the issue and the most likely single cause of excess melt:
+   thin/patchy snow gets hit with a flux sized for a much larger effective bare-ground fraction.
+3. **The soil-top flux is already properly `f_snow`-blended** —
+   [`compute_snow_soil_heat_flux`](../../src/processes/snow/snow_interfaces.jl#L37-L52) computes
+   `f·Q_base + (1-f)·G` for `soil_heat_flux` — but this only fixes the *soil's* boundary condition, not the
+   snowpack's own top-of-pack forcing from step 2.
+4. **Albedo is also bulk-blended before the skin-temperature solve.**
+   [`compute_albedo` (`DiagnosticAlbedo`)](../../src/processes/surface/albedo.jl#L94-L118) computes a single
+   `α_eff = (1-f_snow)(1-f_veg)·α₀ + (1-f_snow)·f_veg·α_veg + f_snow·α_snow` used for the one skin-temperature
+   solve. For small `f_snow` this washes out snow's high albedo, inflating absorbed shortwave (and hence
+   `G`, `Ts`) relative to what the snow-covered patch would actually see — compounding point 2.
+5. A prior design doc ([`2026-07-10_PLAN_01B_surface_ground_heat_flux_split.md`](../2026-07/2026-07-10_PLAN_01B_surface_ground_heat_flux_split.md))
+   already flagged the semantic ambiguity between the SEB closure flux and the soil BC and split them by
+   name (`ground_heat_flux` vs `soil_heat_flux`), fixing the soil side. It explicitly deferred the
+   *snow-top* forcing question — this is that deferred problem.
+
+This is consistent with, and sharpens, the issue text: the reporter suspected the bulk blend was the
+culprit but had not yet traced it all the way to `surface_heat_flux = ground_heat_flux` with **zero**
+`f_snow` weighting at the snow-tendency boundary. That zero-weighting (not just "some blending exists")
+is likely the dominant term, especially for the thin/patchy snow (`f_snow` small) typical of snow onset
+and ablation in shoulder seasons — exactly when spurious melt would show up as chronically-suppressed
+peak SWE.
+
+## Investigation plan (before committing to a fix)
+
+1. **Instrument and confirm the mechanism.** Add a diagnostic run (single grid cell or small regional
+   subset at a northern-latitude site with known snow cover, e.g. from ERA5/CRU forcing already used in
+   existing examples/tests) that logs `f_snow`, `ground_heat_flux` (bulk `G`), `compute_snow_soil_heat_flux`
+   (`Q_base` blend), `snow_temperature`, `skin_temperature`, `albedo`, and the snow energy tendency terms
+   (`Q_top`, `Q_base`, `Q_prcp`, `Q_subl`) through a full autumn-onset → winter → melt cycle. Confirm that
+   (a) `Q_top` tracks the *bulk* `G` rather than a snow-covered-fraction-appropriate flux, and (b) melt
+   events correlate with periods of small `f_snow` (patchy cover) rather than genuine warm spells.
+2. **Quantify the albedo effect in isolation.** With `f_snow` diagnostics from (1), estimate how much
+   absorbed shortwave increases from blended vs. snow-only albedo at representative small-`f_snow` values,
+   to judge whether fixing point 2 alone (without touching albedo) would be enough, or whether point 4
+   also needs addressing per the issue's closing concern.
+3. **Check `snow_cover_fraction`'s functional form** ([`snow_cover.jl`](../../src/processes/snow/mass/snow_cover.jl))
+   — if it saturates slowly (small `f_snow` for a wide range of low SWE), the zero-weighting bug in point 2
+   would bite hardest exactly during accumulation onset, which matches "not enough snow accumulating."
+4. **Rule out independent causes** before attributing the whole deficit to SEB coupling: verify
+   snowfall-phase partitioning (rain/snow split by `T_air`), sublimation magnitude
+   ([`compute_snow_sublimation_flux`](../../src/processes/snow/mass/snow_mass.jl#L13-L29)), and the
+   `min_conduction_thickness` floor behavior for very thin packs (already flagged as thermally transient by
+   design — worth confirming it isn't itself injecting spurious heat during pack initiation).
+
+## Candidate fixes (in increasing order of scope)
+
+**Fix A — weight the snowpack's top-of-pack flux by `f_snow` (minimal, addresses point 2 directly).**
+Instead of aliasing `surface_heat_flux = ground_heat_flux` unweighted, apply the same `f_snow` blend
+already used for the soil side: derive a snow-only top flux and multiply, or (more physically) recognize
+that with `f_snow` already baked into the *conduction target* (`Tg_eff`, `κ_eff`, `Δz_eff` blend) `G` is
+not simply separable into "the snow's share" — this needs care, not just multiplying `G` by `f_snow`
+(that alone would not correct the albedo/conduction-target distortion in point 4, only rescale the
+already-distorted flux). This is the smallest change but only partially matches the issue's own proposed
+interim fix.
+
+**Fix B — issue's proposed interim fix: fix `ground_heat_flux` to the true ground interface and
+explicitly partition `G_g`/`G_s` in the SEB residual.** Redefine the skin-temperature residual as
+`R_net(Ts) + H(Ts) + LE(Ts) - G_g(Ts) - G_s(Ts) = 0`, where `G_g` uses the snow-free conduction target
+(pure ground) and `G_s` uses the pure-snow conduction target, each weighted by `(1-f_snow)`/`f_snow`
+respectively (no blending of `Tg`/`κ`/`Δz` themselves — only the two resulting fluxes are combined).
+`G_s` (or `G_s/f_snow`, the per-area snow flux) then drives the snowpack tendency directly, replacing the
+current unweighted alias. This directly fixes point 2 and is a bounded, well-specified change to
+`skin_temperature.jl` (new `compute_ground_heat_flux` partition), `land_model.jl` (wire `surface_heat_flux`
+to the new `G_s`-derived field instead of raw `ground_heat_flux`), and `snow_interfaces.jl` (`Q_base` blend
+becomes consistent with `G_s`'s ground-facing counterpart, avoiding double-counting). Leaves the
+single-albedo/single-`Ts` limitation (point 4) unresolved, as the issue itself notes.
+
+**Fix C — full tiling.** Solve the SEB independently for the snow-covered and snow-free sub-fractions
+(two skin temperatures, two albedos, two turbulent-flux solves), then area-weight only the *aggregate*
+diagnostics (mean skin temperature for output, total sensible/latent flux for atmosphere coupling). This
+is the "ideal" fix per the issue and resolves both point 2 and point 4, but is a substantially larger
+change: doubles the per-cell nonlinear solve cost, touches `SurfaceEnergyBalance`, `skin_temperature.jl`,
+`turbulent_fluxes.jl`, `radiative_fluxes.jl`, `albedo.jl`, and the snow/soil coupling in `land_model.jl`
+and `snow_interfaces.jl`. Also raises open questions about how vegetation fraction composes with snow
+tiling (currently vegetation and snow fractions are both blended into the same single albedo formula) and
+about GPU/Reactant kernel cost of two solves per cell.
+
+## Recommendation
+
+Run the investigation steps first (mechanism confirmation is cheap and will validate whether Fix B alone
+is sufficient before committing to the much larger Fix C). Given the issue author's own framing ("another
+interim solution" for B, deferred judgement on tiling pending their own investigation), propose starting
+with **Fix B** as a scoped, physically-motivated interim PR, explicitly flagging the residual
+single-albedo limitation as known-limitation / future-work (candidate follow-up: apply the same `G_g`/`G_s`
+partition idea to albedo, i.e. compute `R_net` twice with `α_ground`/`α_snow` and combine post-hoc, without
+going all the way to full turbulent-flux tiling — worth scoping as **Fix B+** if the investigation shows
+albedo blending is still a significant residual error after B).
+
+## Summary of changes
+
+(To be filled in once a fix is selected and approved — this document currently proposes B as the
+scoped candidate. No code changes have been made yet.)
+
+## Testing and verification
+
+- Regression test: no-snow behavior must be bit-for-bit unchanged (same pattern as PR-B in
+  `2026-07-10_PLAN_01B_surface_ground_heat_flux_split.md`).
+- New unit test(s) in `test/snow/` (or `test/surface/`) exercising the SEB residual with partitioned
+  `G_g`/`G_s` at a few `f_snow` values, checking energy conservation: `G_g + G_s` (area-weighted) should
+  recover the same total ground-column energy input as today's bulk `G` in the `f_snow → 0` and
+  `f_snow → 1` limits.
+- End-to-end site-level regression against the northern-latitude case used in the investigation step,
+  checking peak SWE and snow-season length against a reasonable reference (reanalysis snow cover or a
+  previous known-good model version, if available).
+- Differentiability: re-run `test/differentiability` and `test/reactant/autodiff.jl` relevant snow/SEB
+  cases after the change, since `compute_ground_heat_flux` and `ground_thermal_interface` sit inside the
+  implicit skin-temperature solve's differentiated call graph.
+
+## Documentation changes
+
+- Update the SEB residual equation and prose in the `ImplicitSkinTemperature` docstring
+  ([`skin_temperature.jl:42-50`](../../src/processes/surface/skin_temperature.jl#L42-L50)) to reflect the
+  `G_g`/`G_s` partition.
+- Update `docs/src` process pages for surface energy balance / snow coupling (per `AGENTS.md` doc-page
+  conventions: Overview/Implementations/Methods/Kernel-functions sections) once the concrete
+  implementation is decided.
+
+## Known limitations
+
+- Fix B does not address the aggregated-albedo distortion of `R_net` (issue's closing concern); this
+  remains until Fix B+ or full tiling (Fix C) is implemented.
+- Fix B still solves a single skin temperature, so turbulent fluxes (`H_s`, `H_l`) are not tiled either —
+  only the conductive term is partitioned.
+
+## Future work
+
+- Full tiling (Fix C), if the investigation or Fix B's post-hoc evaluation shows residual error from the
+  shared skin temperature/albedo is still significant.
+- Revisit `snow_cover_fraction`'s functional form if step 3 of the investigation shows pathological
+  behavior at low SWE.

--- a/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
+++ b/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
@@ -1,9 +1,11 @@
 # Investigation: insufficient high-latitude winter snow accumulation (SEB/snow-fraction coupling)
 
-> Status: **in progress**. Plan approved; mechanism confirmed empirically (single-column diagnostic:
-> 0% of cumulative snowfall retained under permanently-sub-zero forcing). Proceeding with Fix B
-> (SEB `G`/`S` conductive-flux partition). Investigation step 3 (snow-cover-fraction functional form)
-> skipped per author direction.
+> Status: **completed** (pending final CI/doc-build check). Three independent bugs identified and fixed:
+> (1) the SEB `G`/`S` blending issue (Fix B, as planned), (2) a snow-energy-tendency gate that zeroed
+> cold-snow advection on the very first accumulation step, (3) a `min_conduction_thickness` floor that
+> diluted a thin pack's liquid-fraction diagnosis toward "melted". All three were needed to actually
+> resolve the reported symptom — Fix B alone did not (see Rev 4/5 below). Full regression suite
+> (snow/coupled-model/skin-temperature tests, 7776-case stress sweep) passes.
 
 Date of initial draft: 2026-08-27
 
@@ -40,6 +42,40 @@ still sees an unrealistic radiation budget.
   timestep once it forms (0% of cumulative snowfall retained over 45 days). Steps 1 and 4 marked
   complete; step 2 (albedo) folded in as a retained known limitation, not separately quantifiable in this
   configuration.
+- Rev 4 (2026-08-27): implemented Fix B. Design refined during implementation per author direction: kept
+  the existing closed-form Ts-space Newton inversion (proven equivalent in iteration count to a
+  flux-space residual — verified algebraically, `f_a(Ts) = f_b(Ts)/A` exactly, since the total conductance
+  `A` is `Ts`-independent), but made `ImplicitSkinTemperature`'s `ground_heat_flux` an *explicit*
+  conductive-flux dispatch (function of the current `Ts`) rather than deriving it from the atmosphere-side
+  demand — this is what actually resolves the storage ambiguity, decoupled from the solver mechanism
+  itself. Full test suite (skin-temperature stress test incl. snow cases, snow/coupled-model regressions)
+  passes. **Re-ran the step-1 diagnostic after Fix B: still 0% retention** — Fix B alone did not resolve
+  the reported symptom in this scenario.
+- Rev 5 (2026-08-27): traced the persistent 0%-retention result (with Fix B in place) to two further,
+  independent bugs, found by isolating the standalone `SnowModel` energy tendency with all SEB forcing set
+  to zero:
+  1. `compute_snow_energy_tendency`'s `(W > 0)` gate (`snow_energy.jl`) zeroed the *entire* tendency,
+     including the cold-snow precipitation-advection term `Q_prcp`, on the first step any snow accumulates
+     onto bare ground (`W` read before that step's mass increment). Fresh snow entered with `Ū_snow = 0`,
+     which the `FreeWater` closure reads as instantaneously fully melted. Fixed by excluding `Q_prcp` from
+     the gate (it is a pure source term, always well-defined, unlike the conductive/sublimation terms).
+  2. `energy_to_temperature!`'s (`snow_energy_closures.jl`) liquid-fraction calculation shared the same
+     `min_conduction_thickness`-floored volumetric energy as the temperature calculation. The floor is
+     needed for temperature (protects the conductive fluxes from an unbounded result as depth → 0) but
+     actively harmful for liquid fraction (`liquid_water_fraction` self-clamps to `[0,1]` regardless of
+     magnitude, so no floor is needed there, and the floor was diluting a genuinely cold, thin layer's
+     energy density toward the melting threshold). Fixed by computing `liq` from the *unfloored*
+     depth-integrated comparison `liquid_water_fraction(FreeWater(), Ū_snow, d_snow * ρLθ)` (still safely
+     gated by `W_snow > 0` to avoid a `1`-when-empty artifact), while `T` keeps the floored volumetric path.
+  Both fixed; author iterated on the exact formulation live in the editor (several intermediate attempts —
+  `W_snow * ρLθ` instead of `d_snow * ρLθ`, dropping the `W_snow > 0` gate, an unfloored `T` via
+  `d_snow * C_snow` — were each checked and corrected before landing on the final form; see the file's
+  current state for the settled implementation). Full regression suite re-run and passes. Diagnostic
+  re-run after all three fixes: pathological all-or-nothing oscillation gone (`f_snow` and `T_snow` now
+  vary smoothly/physically instead of pinning at exactly `0`/`0°C` every other step); the diagnostic's own
+  weak synthetic forcing (fixed longwave, minimal solar, no realistic winter energy balance) still yields
+  low net retention in that toy scenario, which is a forcing-realism limitation of the reproducer, not the
+  bug pattern under investigation.
 
 ## Problem description
 
@@ -210,23 +246,74 @@ the investigation shows it's still a significant residual error after B.
 
 ## Summary of changes
 
-(To be filled in once a fix is selected and approved — this document currently proposes B as the
-scoped candidate. No code changes have been made yet.)
+**`src/processes/surface/skin_temperature.jl`** (Fix B):
+- `ground_thermal_interface(i, j, grid, fields, skinT::ImplicitSkinTemperature)` no longer takes `snow`:
+  it is now *always* the unblended, snow-free ground conduction target `(Tg, κₛ, Δz)`.
+- New `snow_conduction_interface(i, j, grid, fields, snow, constants)`: the unblended snow-top target
+  `(Tsnow, κsnow, dsnow)`, floored at `min_conduction_thickness`; `snow === nothing` returns a finite,
+  zero-conductivity placeholder (safe against `0 * Inf`).
+- `compute_skin_temperature(::ImplicitSkinTemperature, G, Tg, κg, Δzg, f_snow, Tsnow, κsnow, dsnow)`: the
+  closed-form Newton-residual inversion, generalized from one to two parallel (area-weighted) conductances;
+  exact algebraic solve, not an approximation (conduction is linear in `Ts`; only `R_net`/`H`/`LE` are
+  nonlinear).
+- New `compute_ground_heat_flux(i, j, grid, fields, skinT::ImplicitSkinTemperature, seb)` override: stores
+  the *explicit* conductive flux `2κg(Tg − Ts)/Δzg` at the current `Ts`, replacing the generic
+  `R_net + H_s + H_l` dispatch inherited from `AbstractSkinTemperature` (still used by
+  `PrescribedSkinTemperature`, which has no conduction target to be explicit about).
+- `compute_skin_temperature_residual!` recomputes the atmosphere-side demand separately (no longer reads
+  it back from `ground_heat_flux`, whose meaning changed above) and inverts it through both conduction
+  targets.
+
+**`src/processes/snow/snow_interfaces.jl`**:
+- `compute_snow_soil_heat_flux` unchanged in form (`f·Q_base + (1−f)·G`) but now correct in practice
+  since `G` is the genuinely-explicit bare-ground flux.
+- New `compute_snow_surface_heat_flux`: the snow-top flux `S = 2κsnow(Tsnow − Ts)/dsnow`, computed
+  post-solve at the converged `Ts` and stored into the new `surface_heat_flux`/`snow_surface_heat_flux`
+  field, replacing the old unweighted alias to `ground_heat_flux`.
+
+**`src/models/coupled/land_model.jl`**: `surface_heat_flux` is now its own allocated field
+(`snow_surface_heat_flux`) rather than an alias of `ground_heat_flux`, mirroring the existing
+`soil_heat_flux` pattern (aliased to `ground_heat_flux` only in the no-snow case).
+
+**`src/processes/snow/energy/snow_energy.jl`** (gate fix): `compute_snow_energy_tendency`'s
+`(Q_base − Q_top + Q_prcp + Q_subl) * (W > 0)` gate changed to `(Q_base − Q_top + Q_subl) * (W > 0) + Q_prcp`
+— `Q_prcp` (cold-snow advection) is no longer suppressed on the accumulation-onset step.
+
+**`src/processes/snow/energy/snow_energy_closures.jl`** (closure fix): `energy_to_temperature!` now
+computes `snow_liquid_fraction` from the unfloored, depth-integrated
+`liquid_water_fraction(FreeWater(), Ū_snow, d_snow * ρLθ)` (still gated by `W_snow > 0`), while
+`snow_temperature` continues to use the floored volumetric `U_snow`/`ρLθ`/`C_snow` path — decoupling two
+consumers of the same underlying quantity that had different numerical needs.
+
+**`test/surface/skin_temperature.jl`**: convergence-check helper rewritten to reconstruct the residual
+explicitly (atmosphere-side demand vs. area-weighted `G`/`S` conduction) rather than calling the removed
+blended `ground_thermal_interface` overload.
+
+**`test/snow/snow_model_tests.jl`**: new regression test, "snowfall onto bare ground (W=0) advects cold,
+not zero", pinning the gate-fix behavior.
 
 ## Testing and verification
 
-- Regression test: no-snow behavior must be bit-for-bit unchanged (same pattern as PR-B in
-  `2026-07-10_PLAN_01B_surface_ground_heat_flux_split.md`).
-- New unit test(s) in `test/snow/` (or `test/surface/`) exercising the SEB residual with partitioned
-  `G_g`/`G_s` at a few `f_snow` values, checking energy conservation: `G_g + G_s` (area-weighted) should
-  recover the same total ground-column energy input as today's bulk `G` in the `f_snow → 0` and
-  `f_snow → 1` limits.
-- End-to-end site-level regression against the northern-latitude case used in the investigation step,
-  checking peak SWE and snow-season length against a reasonable reference (reanalysis snow cover or a
-  previous known-good model version, if available).
+Performed:
+- Full `test/surface/skin_temperature.jl` (includes the 7776-case `LandModel` stress sweep over
+  snow/no-snow × radiation/temperature/humidity/wind combinations): **pass**.
+- `test/snow/snow_model_tests.jl`, `snow_energy_tests.jl`, `snow_properties_tests.jl`,
+  `test/coupled_models/land_model_tests.jl`, `test/surface/diagnostic_albedo_tests.jl`: **pass**
+  (119 total, including the new regression test), re-run after each of the three fixes landed.
+- Empirical mechanism confirmation and fix verification via
+  `scratch/debugging/snow_seb_partition_investigation.jl` (see Rev 3–5 above): pathological
+  all-or-nothing SWE oscillation eliminated; `f_snow`/`T_snow` now vary smoothly and physically.
+
+Not yet performed (recommended before merge):
 - Differentiability: re-run `test/differentiability` and `test/reactant/autodiff.jl` relevant snow/SEB
-  cases after the change, since `compute_ground_heat_flux` and `ground_thermal_interface` sit inside the
-  implicit skin-temperature solve's differentiated call graph.
+  cases, since `compute_ground_heat_flux`, `ground_thermal_interface`, and `snow_conduction_interface`
+  sit inside the implicit skin-temperature solve's differentiated call graph, and
+  `energy_to_temperature!`'s branch structure changed.
+- Full doc build (`julia --project=docs docs/make.jl --local --draft`) — the `ImplicitSkinTemperature`
+  docstring's residual equation was updated; needs a build check for stale `@docs`/doctest references.
+- A realistic (ERA5-forced) end-to-end regression at a northern-latitude site, since the diagnostic
+  script's synthetic forcing was not tuned to validate actual peak-SWE/season-length magnitudes — only
+  to reproduce and check the specific oscillation pathology.
 
 ## Documentation changes
 
@@ -243,6 +330,12 @@ scoped candidate. No code changes have been made yet.)
   remains until Fix B+ or full tiling (Fix C) is implemented.
 - Fix B still solves a single skin temperature, so turbulent fluxes (`H_s`, `H_l`) are not tiled either —
   only the conductive term is partitioned.
+- `ImplicitSkinTemperature`'s ground conduction target still uses the assumed constant `κₛ` parameter
+  rather than the soil model's own (moisture/ice-state-dependent) thermal conductivity — a
+  longstanding simplification, not something this investigation's fixes touch. Assessed as a scoped
+  follow-up (see Future work).
+- The diagnostic script's synthetic forcing has not been validated against realistic peak-SWE magnitudes
+  (see Testing and verification).
 
 ## Future work
 
@@ -250,3 +343,18 @@ scoped candidate. No code changes have been made yet.)
   shared skin temperature/albedo is still significant.
 - Revisit `snow_cover_fraction`'s functional form if step 3 of the investigation shows pathological
   behavior at low SWE.
+- **Use the soil model's actual (state-dependent) thermal conductivity in `ground_thermal_interface`**
+  instead of the assumed constant `κₛ`. Scoped assessment (2026-08-27): `compute_thermal_conductivity`
+  already exists (`soil_thermal_properties.jl`/`soil_energy.jl`), computed from `soil_composition`
+  (porosity, saturation, liquid fraction, solid matrix — needs the soil's stratigraphy/hydrology/
+  biogeochemistry components) at a given `(i,j,k)`; the top-layer view pattern already used for
+  `ground_temperature` is a direct template. Would require threading an `Optional{AbstractSoil}` through
+  `solve_surface_energy_balance!` → the fused kernel → `solve_skin_temperature!` →
+  `compute_skin_temperature_residual!` → `ground_thermal_interface` (mirroring the existing
+  `Optional{AbstractSnow}`/`Optional{AbstractSurfaceHydrology}` pattern), merging soil's hydrology/strat/
+  bgc fields into the SEB kernel's field set, and evaluating `soil_composition`/`compute_thermal_conductivity`
+  at a fixed `k = Nz` inside the otherwise-2D `XY` SEB kernel. `κₛ` would stay as the fallback for
+  `soil === nothing` (standalone `SurfaceEnergyModel`, used by existing smoke tests). Rough size: similar
+  order of magnitude to Fix B (a handful of files, ~100–150 lines, a few hours including tests) — real but
+  bounded; warrants its own short plan doc before implementation, since it's a new SEB↔soil coupling
+  dependency, not a bug fix.

--- a/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
+++ b/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
@@ -1,11 +1,11 @@
 # Investigation: insufficient high-latitude winter snow accumulation (SEB/snow-fraction coupling)
 
-> Status: **completed** (pending final CI/doc-build check). Three independent bugs identified and fixed:
-> (1) the SEB `G`/`S` blending issue (Fix B, as planned), (2) a snow-energy-tendency gate that zeroed
-> cold-snow advection on the very first accumulation step, (3) a `min_conduction_thickness` floor that
-> diluted a thin pack's liquid-fraction diagnosis toward "melted". All three were needed to actually
-> resolve the reported symptom — Fix B alone did not (see Rev 4/5 below). Full regression suite
-> (snow/coupled-model/skin-temperature tests, 7776-case stress sweep) passes.
+> Status: **in progress**. Three independent bugs from the original investigation identified and fixed
+> (Fix B `G`/`S` blending, the accumulation-onset energy gate, the liquid-fraction floor dilution — see
+> Rev 4/5). A residual bug then surfaced in a real coupled SpeedyWeather+Terrarium run (Rev 6): the
+> snow-top conductive flux is explicit-Euler *numerically unstable* at the default
+> `min_conduction_thickness`, causing spurious full-Darcy-drainage events that still suppress winter
+> accumulation. Rev 6 fix (three parts) approved, not yet implemented.
 
 Date of initial draft: 2026-08-27
 
@@ -72,6 +72,20 @@ still sees an unrealistic radiation budget.
   `d_snow * C_snow` — were each checked and corrected before landing on the final form; see the file's
   current state for the settled implementation). Full regression suite re-run and passes. Diagnostic
   re-run after all three fixes: pathological all-or-nothing oscillation gone (`f_snow` and `T_snow` now
+- Rev 6 (2026-08-27): a coupled SpeedyWeather+Terrarium year-long run (`outputs/run_0005`) still showed
+  near-zero NH winter SWE and spurious summer spikes. A targeted single-column diagnostic
+  (`scratch/debugging/snow_mass_leak_investigation.jl`, cold Siberian-winter forcing) traced this to a
+  fourth, independent issue: `compute_snow_surface_heat_flux`'s conductive term
+  `2κ_snow(T_snow − T_s)/max(d_snow, min_conduction_thickness)` is *explicit-Euler numerically unstable*
+  at the default `min_conduction_thickness = 5mm` and the land model's `Δt = 300s` — the implied
+  relaxation timescale `τ = C_snow·d_min²/(2κ_snow) ≈ 30s` is ~9× shorter than `Δt`, so `T_snow` overshoots
+  and oscillates every step between ≈0°C and ≈−70°C. When it lands on the warm side, the depth-integrated
+  energy swings positive, `snow_liquid_fraction` snaps to 1.0, and the Darcy meltwater term fires at its
+  fully-saturated rate, wiping out accumulated SWE in a single step. Confirmed both the mechanism (direct
+  per-step trace of `Qtop`, `U`, `liq`) and a candidate fix empirically: setting
+  `min_conduction_thickness = 0.02` (pushing `τ` above `Δt`) eliminates the oscillation, `liq` stays 0,
+  and SWE accumulates ~100% of forced snowfall over a 30-day cold run (vs. ~0% before). Author approved
+  three follow-up changes (not yet implemented), scoped below under "Rev 6 fix — approved, in progress".
   vary smoothly/physically instead of pinning at exactly `0`/`0°C` every other step); the diagnostic's own
   weak synthetic forcing (fixed longwave, minimal solar, no realistic winter energy balance) still yields
   low net retention in that toy scenario, which is a forcing-realism limitation of the reproducer, not the
@@ -243,6 +257,34 @@ confirmation is cheap and de-risks the implementation); step 3 is out of scope. 
 limitation (point 4 of the Background section) is accepted as a known limitation for this PR, with
 **Fix B+** (post-hoc dual-albedo `R_net`) or full tiling (**Fix C**) as candidate future work if step 2 of
 the investigation shows it's still a significant residual error after B.
+
+## Rev 6 fix — approved, in progress
+
+Root cause is a fixed, too-small `min_conduction_thickness` making the explicit snow-top conduction
+update numerically unstable at the model's `Δt`. Approved fix (three parts):
+
+1. **Remove `min_conduction_thickness` as a `SingleLayerSnow` struct field.** Replace every read of
+   `snow.min_conduction_thickness` (`skin_temperature.jl:105`, `snow_energy_closures.jl:117`, and the
+   basal-flux call site moved per item 3) with a dynamically-computed value: half the thickness of the
+   uppermost soil grid cell, via `Δzᵃᵃᶜ(i, j, field_grid.Nz, field_grid) / 2` (same
+   `get_field_grid(grid)` pattern already used in `ground_thermal_interface`). This scales the floor with
+   the actual grid resolution instead of a fixed constant, and ties it to the same length scale already
+   used for the ground conduction target. `NF` remains pinned in the struct via `<: AbstractSnow{NF}`
+   (verified — Julia permits the "phantom" type parameter; no other struct/constructor change needed
+   beyond dropping the field and kwarg).
+2. **Add `cell_diffusion_timescale` for snow**, mirroring
+   `src/processes/soil/soil_diffusion_timescales.jl`'s pattern (`τ = Δz²C/κ` via
+   `KernelFunctionOperation` + `minimum(τ)`, `Inf` fallback where not applicable). Wire it into
+   `LandModel`'s `cell_diffusion_timescale(state, model::LandModel)` (currently soil-only,
+   `timesteppers/cell_diffusion_timescale.jl`) as `min(soil_τ, snow_τ)`, so `TimeStepWizard` respects the
+   snow conduction stability limit directly instead of relying on a hand-tuned floor.
+3. **Fix `compute_snow_basal_heat_flux` to include the soil-side resistance.** Currently
+   `Q_base = 2κ_snow(T_soil − T_snow)/max(d_snow, d_min)` (`snow_energy.jl:142-143`) omits the soil
+   half-cell's own resistance (`Δz_soil/(2κ_soil)`), implicitly assuming it's negligible next to the
+   snow's — invalid once `d_snow`/the floor is comparable to `Δz_soil/2`. Move the function from
+   `snow_energy.jl` to `snow_interfaces.jl` (its only caller, `compute_snow_soil_heat_flux`, already lives
+   there and already takes `soil`; `snow_energy.jl` stays soil-independent) and change it to a proper
+   series-resistance formula, `Q_base = (T_soil − T_snow) / (Δz_soil/(2κ_soil) + d_snow/(2κ_snow))`.
 
 ## Summary of changes
 

--- a/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
+++ b/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
@@ -1,11 +1,15 @@
 # Investigation: insufficient high-latitude winter snow accumulation (SEB/snow-fraction coupling)
 
-> Status: **in progress**. Three independent bugs from the original investigation identified and fixed
+> Status: **completed**. Four independent bugs from the original investigation identified and fixed
 > (Fix B `G`/`S` blending, the accumulation-onset energy gate, the liquid-fraction floor dilution — see
-> Rev 4/5). A residual bug then surfaced in a real coupled SpeedyWeather+Terrarium run (Rev 6): the
-> snow-top conductive flux is explicit-Euler *numerically unstable* at the default
-> `min_conduction_thickness`, causing spurious full-Darcy-drainage events that still suppress winter
-> accumulation. Rev 6 fix (three parts) approved, not yet implemented.
+> Rev 4/5 — and the Rev 6 explicit-Euler snow-top-conduction instability, see Rev 6/7/8 below). All fixes
+> verified in a real coupled SpeedyWeather+Terrarium run: a 1-year run (`outputs/run_0008`) shows a
+> physically correct seasonal snow cycle at representative mid/high-latitude NH sites — winter
+> accumulation, spring peak, full summer melt-out tracking skin temperature crossing 0°C, autumn
+> re-accumulation — with zero single-step drainage-wipeout events anywhere on the globe over the full
+> year (Rev 8). The differentiability CI failure on the new soil-dependent `compute_snow_basal_heat_flux`
+> is fixed and confirmed passing (Rev 9): full `test/differentiability/snow_model_diff.jl` run, all
+> testsets pass including the rewritten "Snow basal heat flux: differentiability" (4/4).
 
 Date of initial draft: 2026-08-27
 
@@ -85,11 +89,61 @@ still sees an unrealistic radiation budget.
   per-step trace of `Qtop`, `U`, `liq`) and a candidate fix empirically: setting
   `min_conduction_thickness = 0.02` (pushing `τ` above `Δt`) eliminates the oscillation, `liq` stays 0,
   and SWE accumulates ~100% of forced snowfall over a 30-day cold run (vs. ~0% before). Author approved
-  three follow-up changes (not yet implemented), scoped below under "Rev 6 fix — approved, in progress".
+  three follow-up changes, scoped below under "Rev 6 fix — approved, in progress".
   vary smoothly/physically instead of pinning at exactly `0`/`0°C` every other step); the diagnostic's own
   weak synthetic forcing (fixed longwave, minimal solar, no realistic winter energy balance) still yields
   low net retention in that toy scenario, which is a forcing-realism limitation of the reproducer, not the
   bug pattern under investigation.
+- Rev 7 (2026-08-27): implemented the three Rev 6 fixes. During implementation, two corrections from the
+  author refined the design: (1) the new `min_snow_conduction_thickness(i, j, grid, fields, ::SingleLayerSnow)`
+  helper belongs in `snow_single_layer.jl` (snow code), not `skin_temperature.jl`, since it is also needed
+  by the volumetric snow energy closure; (2) its signature was made consistent with the general snow-accessor
+  convention (`i, j, grid, fields, ::SingleLayerSnow`) rather than a bare `(i, j, grid)`. A third correction
+  fixed the new `cell_diffusion_timescale` for snow to use `max(snow_depth(...), min_snow_conduction_thickness(...))`
+  for `d_snow`, matching the floor pattern used everywhere else, rather than the floor alone. Verified: the
+  rewritten `test/snow/snow_energy_tests.jl` basal-flux testset (24/24, checks both thick and vanishing-SWE
+  cases against an independently-reimplemented series-resistance formula); a broader regression run across
+  `test/snow/*`, `test/coupled_models/land_model_tests.jl`, `test/surface/*` (7902/7902 pass); a targeted
+  ad-hoc check of `cell_diffusion_timescale` across SWE = 0, 1e-6, 0.05, 0.5 m confirming it stays finite,
+  floors correctly at the minimum thickness for a vanishing pack, grows quadratically with depth, and that
+  `LandModel`'s combined `min(soil_τ, snow_τ)` dispatch behaves correctly; and a clean local doc build
+  (fixed one incidental broken `@ref` — `[`soil_diffusion_timescales.jl`](@ref)` doesn't resolve to a
+  documented symbol — introduced by the new docstring, changed to reference `[`cell_diffusion_timescale`](@ref)`
+  instead). Not yet done: re-running the coupled SpeedyWeather+Terrarium scenario (`outputs/run_0005`-style)
+  to confirm the original reported NH-winter-SWE symptom is actually resolved end-to-end.
+- Rev 8 (2026-08-27): re-ran the coupled SpeedyWeather+Terrarium scenario with the Rev 6/7 fixes in place,
+  first a 3-month run (`outputs/run_0006`, Jan–Mar) then a full 1-year run (`outputs/run_0008`), analyzed
+  via `xarray`/Python (`geo` conda env, per author preference). `run_0006`: NH (50–90°N) snow depth grows
+  smoothly and monotonically over the winter (mean 0→0.014 m, frac-of-cell->1mm-SWE 0%→62%), a Siberian
+  point (65°N, 90°E) increases every single output step with the largest single-step change over the whole
+  run being 1.5e-5 m (vs. the old pathology's full-pack wipeout every step); zero single-step drops >5mm
+  anywhere in that point series. `run_0008` (full year): a naive zonal-mean check of the 50–90°N band
+  showed net monotonic growth across the *entire* year including NH summer — initially flagged as a
+  possible regression (no seasonal decline) — but resolved by checking individual mid/high-latitude
+  seasonal-snow sites directly (S. Siberia/Mongolia 50°N, US Great Plains 45°N, Scandinavia 60°N): each
+  shows a textbook seasonal cycle — winter accumulation, spring peak, full summer melt-out tightly tracking
+  skin temperature crossing 0°C (e.g. Great Plains: SWE 0.023 m in March → ~5e-7 m by July as skin
+  temperature rises from −6.7°C to +13.5°C), then autumn re-accumulation. The zonal-mean band average is
+  dominated by the permanent high Arctic (75–90°N, real-world firn/glacier accumulation zone that would not
+  be expected to melt out within a single year even in reality), so its monotonic growth is not itself
+  evidence of a bug — same explanation for the analogous SH 50–90°S (Antarctica) pattern. Globally over the
+  full year: zero (time, lat, lon) grid cells with a >20 mm single-step drop — the old drainage-wipeout
+  signature is completely absent. Original reported symptom (near-zero NH winter SWE, sporadic summer
+  spikes) confirmed resolved.
+- Rev 9 (2026-08-27): GitHub CI's Enzyme differentiability job failed —
+  `test/differentiability/snow_model_diff.jl`'s "Snow basal heat flux: differentiability" testset called
+  the removed pure-scalar `compute_snow_basal_heat_flux(κ, T_soil, T_snow, d_snow, d_min)` signature (an
+  artifact of Rev 7 moving the function to a field-based `(i, j, grid, fields, snow, soil, constants)`
+  interface without updating this test). Rewritten to differentiate the real function directly via
+  `Duplicated(state, dstate)` (mirroring the `closure!`-differentiation pattern already used in
+  `soil_hydrology_diff.jl`), checking `∂Q_base/∂T_soil` and `∂Q_base/∂T_snow` are finite and satisfy the
+  closed-form relation (equal, opposite sign, since `Q_base` is linear in both temperatures). First attempt
+  differentiated a full `LandModel` `timestep!` (mirroring the file's own "Snow model: timestep!" pattern);
+  author redirected to keep the test focused specifically on `compute_snow_basal_heat_flux` rather than the
+  whole coupled step. Confirmed passing: full standalone run of `test/differentiability/snow_model_diff.jl`,
+  all testsets pass, including the rewritten "Snow basal heat flux: differentiability" (4/4, 1m22s) and the
+  pre-existing "Snow model: timestep!" (4/4, 24m17s — long Enzyme compilation of the full snow-model
+  reverse-mode call graph, expected and unaffected by this change).
 
 ## Problem description
 
@@ -258,7 +312,7 @@ limitation (point 4 of the Background section) is accepted as a known limitation
 **Fix B+** (post-hoc dual-albedo `R_net`) or full tiling (**Fix C**) as candidate future work if step 2 of
 the investigation shows it's still a significant residual error after B.
 
-## Rev 6 fix — approved, in progress
+## Rev 6 fix — implemented and verified (Rev 7)
 
 Root cause is a fixed, too-small `min_conduction_thickness` making the explicit snow-top conduction
 update numerically unstable at the model's `Δt`. Approved fix (three parts):
@@ -356,6 +410,44 @@ Not yet performed (recommended before merge):
 - A realistic (ERA5-forced) end-to-end regression at a northern-latitude site, since the diagnostic
   script's synthetic forcing was not tuned to validate actual peak-SWE/season-length magnitudes — only
   to reproduce and check the specific oscillation pathology.
+
+Rev 6/7 fix (grid-derived `min_conduction_thickness`, snow `cell_diffusion_timescale`, soil-inclusive
+basal-flux series resistance) — performed:
+- `test/snow/snow_energy_tests.jl` rewritten basal-flux testset: **24/24 pass**, covering both thick
+  (`W=0.5`) and vanishing/zero SWE (`W ∈ {0, 1e-9, 1e-6}`) cases against an independently-reimplemented
+  series-resistance formula.
+- Broader regression: `test/snow/*`, `test/coupled_models/land_model_tests.jl`, `test/surface/*` —
+  **7902/7902 pass**.
+- Ad-hoc `cell_diffusion_timescale` sanity check (single-column `LandModel`, SWE = 0, 1e-6, 0.05, 0.5 m):
+  stays finite and positive throughout; floors correctly (identical τ at W=0 and W=1e-6, both far below
+  the grid-derived minimum thickness); grows quadratically with snow depth once past the floor
+  (τ ≈ 1.98e3 s → 1.27e5 s → 1.27e7 s across W = 0/1e-6 → 0.05 → 0.5); `LandModel`'s
+  `min(soil_τ, snow_τ)` combination dispatch behaves correctly (soil, at ≈1090 s, dominates whenever
+  snow is thin/absent).
+- Clean local doc build (`julia --project=docs docs/make.jl --local --draft`, exit 0): fixed one
+  incidental broken `@ref` introduced by the new `cell_diffusion_timescale` docstring
+  (`[`soil_diffusion_timescales.jl`](@ref)` doesn't resolve — filenames aren't `@ref` targets — changed to
+  `[`cell_diffusion_timescale`](@ref)`); no other new warnings versus the pre-existing baseline.
+
+Rev 8 (coupled-run confirmation) — performed:
+- 3-month coupled run (`outputs/run_0006`, Jan–Mar): smooth monotonic NH winter accumulation, no
+  single-step oscillation/drainage; see Rev 8 revision-log entry for full figures.
+- 1-year coupled run (`outputs/run_0008`): individual seasonal-snow sites (S. Siberia/Mongolia 50°N,
+  US Great Plains 45°N, Scandinavia 60°N) each show a correct full accumulation → peak → melt-out → 
+  re-accumulation annual cycle tracking skin temperature; zero single-step drops >20mm anywhere on the
+  globe over the full year. Original reported symptom (near-zero NH winter SWE, sporadic summer spikes)
+  confirmed resolved end-to-end, not just in the single-column diagnostic.
+
+Rev 9 (differentiability) — performed:
+- GitHub CI's Enzyme job failed on the stale `compute_snow_basal_heat_flux` scalar-signature test (see
+  Rev 9 revision-log entry). Rewritten to differentiate the real field-based function via
+  `Duplicated(state, dstate)`; standalone run of `test/differentiability/snow_model_diff.jl` **passes in
+  full** (all testsets, including the rewritten one, 4/4).
+
+Still not yet performed (recommended before merge):
+- Differentiability re-check for `cell_diffusion_timescale`/`min_snow_conduction_thickness` specifically
+  (distinct from the `compute_snow_basal_heat_flux` test above) and `test/reactant/autodiff.jl` coverage
+  for any of the Rev 6/7 changes.
 
 ## Documentation changes
 

--- a/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
+++ b/docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md
@@ -1,7 +1,9 @@
 # Investigation: insufficient high-latitude winter snow accumulation (SEB/snow-fraction coupling)
 
-> Status: **planned**. Investigation + candidate fixes for the reported bug (SWE < 0.001 m at northern
-> latitudes in winter, likely from excessive melt).
+> Status: **in progress**. Plan approved; mechanism confirmed empirically (single-column diagnostic:
+> 0% of cumulative snowfall retained under permanently-sub-zero forcing). Proceeding with Fix B
+> (SEB `G`/`S` conductive-flux partition). Investigation step 3 (snow-cover-fraction functional form)
+> skipped per author direction.
 
 Date of initial draft: 2026-08-27
 
@@ -29,6 +31,15 @@ still sees an unrealistic radiation budget.
 
 - Rev 1 (2026-08-27): initial draft from code review of `skin_temperature.jl`, `surface_energy_balance.jl`,
   `snow_energy.jl`, `snow_interfaces.jl`, `albedo.jl`, and `land_model.jl`.
+- Rev 2 (2026-08-27): approved by author. Fix B selected as the target implementation. Investigation
+  step 3 (`snow_cover_fraction` functional-form check) dropped from scope; steps 1, 2, and 4 remain.
+  Author clarified Fix B's `S` (formerly `G_s`) is the skin→snow-top conductive flux, distinct from
+  the existing snow-base→soil flux `Q_base`; Fix B section rewritten accordingly.
+- Rev 3 (2026-08-27): ran the step-1 diagnostic (single-column `LandModel`, permanently sub-zero forcing).
+  Confirmed the unweighted `surface_heat_flux = ground_heat_flux` alias destroys the snowpack every
+  timestep once it forms (0% of cumulative snowfall retained over 45 days). Steps 1 and 4 marked
+  complete; step 2 (albedo) folded in as a retained known limitation, not separately quantifiable in this
+  configuration.
 
 ## Problem description
 
@@ -91,14 +102,52 @@ peak SWE.
    absorbed shortwave increases from blended vs. snow-only albedo at representative small-`f_snow` values,
    to judge whether fixing point 2 alone (without touching albedo) would be enough, or whether point 4
    also needs addressing per the issue's closing concern.
-3. **Check `snow_cover_fraction`'s functional form** ([`snow_cover.jl`](../../src/processes/snow/mass/snow_cover.jl))
-   — if it saturates slowly (small `f_snow` for a wide range of low SWE), the zero-weighting bug in point 2
-   would bite hardest exactly during accumulation onset, which matches "not enough snow accumulating."
+3. **(Skipped per author direction, rev 2.)** ~~Check `snow_cover_fraction`'s functional form~~ — out of
+   scope for this investigation.
 4. **Rule out independent causes** before attributing the whole deficit to SEB coupling: verify
    snowfall-phase partitioning (rain/snow split by `T_air`), sublimation magnitude
    ([`compute_snow_sublimation_flux`](../../src/processes/snow/mass/snow_mass.jl#L13-L29)), and the
    `min_conduction_thickness` floor behavior for very thin packs (already flagged as thermally transient by
    design — worth confirming it isn't itself injecting spurious heat during pack initiation).
+
+### Step 1 result: mechanism confirmed empirically (rev 2)
+
+Ran a minimal single-column `LandModel` diagnostic
+([`scratch/debugging/snow_seb_partition_investigation.jl`](../../scratch/debugging/snow_seb_partition_investigation.jl),
+log in `/tmp/snow_seb_investigation2.log`): `ColumnGrid` with `SoilEnergyWaterCarbon` + `SingleLayerSnow`
++ `DiagnosticAlbedo` (the `LandModel` default is actually `ConstantAlbedo`, not snow-aware — switched to
+`DiagnosticAlbedo` so the run also exercises point 4), forced with constant light snowfall
+(`1e-7 m/s SWE`), zero rain, air temperature fixed at −8 °C (no diurnal/seasonal cycle — genuine
+air-temperature-driven melt is structurally impossible in this setup), 230 W/m² longwave-down, and zero
+shortwave (polar-night limit). Soil/snow started frozen at −8 °C, `W_swe = 0`.
+
+Per-step trace (`Δt = 300 s`, single column, `f_snow = W/(W + 0.01)`):
+
+```
+step 1: W=2.9999999999999997e-5 f_snow=0.00299 d_snow=0.00012  G(bulk)=42.20  snow_energy=0.0   T_snow=0.0  θ_liq=1.0
+step 2: W=0.0                    f_snow=0.0     d_snow=0.0     G(bulk)=41.06  snow_energy=-0.0  T_snow=0.0  θ_liq=0.0
+step 3: W=2.9999999999999997e-5 f_snow=0.00299  d_snow=0.00012  G(bulk)=39.93  snow_energy=0.0   T_snow=0.0  θ_liq=1.0
+step 4: W=0.0                    f_snow=0.0     d_snow=0.0     G(bulk)=39.37  snow_energy=-0.0  T_snow=0.0  θ_liq=0.0
+```
+
+Within the **same timestep** that a sliver of snow first accumulates (`f_snow ≈ 0.3%`), the pack is
+diagnosed as fully melted (`T_snow = 0 °C`, `θ_liq = 1.0`) and drains completely via the Darcy meltwater
+flux — then the cycle repeats every step for the full 45-day run. Over the whole run: **0.00% of the
+cumulative snowfall input (0.389 m SWE) is retained** (see the script's summary output) — this
+reproduces the `< 0.001 m SWE` symptom directly, with air temperature held permanently sub-zero the
+entire time, ruling out a genuine warm-air melt explanation. This directly implicates the unweighted
+`surface_heat_flux = ground_heat_flux` alias (`land_model.jl:81`): the bulk `G` (~40 W/m², sized for the
+whole cell) is applied unmediated to a snowpack thermal mass bounded by `min_conduction_thickness`
+(5 mm), which cannot absorb a cell-scale flux without being driven straight to (and past) its melting
+point in one step.
+
+Step 1 investigation is considered complete; step 2 (isolating the albedo contribution specifically) is
+superseded in practice by this result — the melt is total and immediate even before the albedo blend has
+a chance to matter over multiple steps, so albedo's marginal contribution is not separable from noise in
+this configuration. It remains a real, distinct problem (per Background point 4) and is retained as a
+known limitation of Fix B. Step 4 (independent causes) is satisfied by construction: air temperature is
+fixed and always sub-zero, so rain-phase partitioning is irrelevant, and sublimation cannot be the melt
+mechanism (`θ_liq` rises with the pack still frozen).
 
 ## Candidate fixes (in increasing order of scope)
 
@@ -111,16 +160,34 @@ not simply separable into "the snow's share" — this needs care, not just multi
 already-distorted flux). This is the smallest change but only partially matches the issue's own proposed
 interim fix.
 
-**Fix B — issue's proposed interim fix: fix `ground_heat_flux` to the true ground interface and
-explicitly partition `G_g`/`G_s` in the SEB residual.** Redefine the skin-temperature residual as
-`R_net(Ts) + H(Ts) + LE(Ts) - G_g(Ts) - G_s(Ts) = 0`, where `G_g` uses the snow-free conduction target
-(pure ground) and `G_s` uses the pure-snow conduction target, each weighted by `(1-f_snow)`/`f_snow`
-respectively (no blending of `Tg`/`κ`/`Δz` themselves — only the two resulting fluxes are combined).
-`G_s` (or `G_s/f_snow`, the per-area snow flux) then drives the snowpack tendency directly, replacing the
-current unweighted alias. This directly fixes point 2 and is a bounded, well-specified change to
-`skin_temperature.jl` (new `compute_ground_heat_flux` partition), `land_model.jl` (wire `surface_heat_flux`
-to the new `G_s`-derived field instead of raw `ground_heat_flux`), and `snow_interfaces.jl` (`Q_base` blend
-becomes consistent with `G_s`'s ground-facing counterpart, avoiding double-counting). Leaves the
+**Fix B — issue's proposed interim fix: partition the SEB residual into a ground-conduction term and a
+snow-top-conduction term.** Redefine the skin-temperature residual as
+`R_net(Ts) + H(Ts) + LE(Ts) - G(Ts) - S(Ts) = 0`, where both `G` and `S` are conductive fluxes *from the
+single shared skin temperature `Ts` downward*, not flux-into-soil terms:
+- `G` = `(1-f_snow)·2κₛ(Ts - T_ground)/Δz_ground` — conduction from the skin into the *snow-free ground*
+  (unchanged meaning from today's no-snow case; this is what already drives the soil BC directly when
+  there is no snow).
+- `S` = `f_snow·2κ_snow(Ts - T_snow)/d_snow` — conduction from the skin into the *top of the snowpack*.
+  This is a new quantity: today there is no separate flux terminating at the snow top at all, only the
+  single blended `G` from the blended conduction target in `ground_thermal_interface`.
+
+Critically, `S` (not `G`, and not blended with it) becomes the field that drives the snowpack's own
+top-of-pack energy tendency (`surface_heat_flux`, read as `Q_top` in
+[`compute_snow_energy_tendency`](../../src/processes/snow/energy/snow_energy.jl#L79-L100)), replacing
+today's unweighted `surface_heat_flux = ground_heat_flux` alias
+([`land_model.jl:81`](../../src/models/coupled/land_model.jl#L81)). `G` continues to drive the soil
+directly over the snow-free fraction, and is *unrelated* to the existing snow→soil basal flux `Q_base`
+(the already-correct [`compute_snow_soil_heat_flux`](../../src/processes/snow/snow_interfaces.jl#L37-L52)
+blend `f_snow·Q_base + (1-f_snow)·G`, which conducts from the snow *base* down into the soil under the
+snow, and is untouched by this fix). So under snow, three distinct conductive fluxes coexist: `G`
+(skin → bare ground, snow-free fraction), `S` (skin → snow top, snow-covered fraction), and `Q_base`
+(snow base → soil top, snow-covered fraction) — Fix B only adds `S` and rewires the snow-tendency
+consumer to use it; `G` and `Q_base` keep their present roles and definitions.
+
+This directly fixes point 2 and is a bounded, well-specified change to `skin_temperature.jl` (the residual
+gains an `S` term computed from an unblended pure-snow conduction target, alongside the existing
+unblended pure-ground `G`), `land_model.jl` (wire `surface_heat_flux` to the new `S` field instead of raw
+`ground_heat_flux`), and no change to `snow_interfaces.jl`'s `Q_base` blend. Leaves the
 single-albedo/single-`Ts` limitation (point 4) unresolved, as the issue itself notes.
 
 **Fix C — full tiling.** Solve the SEB independently for the snow-covered and snow-free sub-fractions
@@ -135,14 +202,11 @@ about GPU/Reactant kernel cost of two solves per cell.
 
 ## Recommendation
 
-Run the investigation steps first (mechanism confirmation is cheap and will validate whether Fix B alone
-is sufficient before committing to the much larger Fix C). Given the issue author's own framing ("another
-interim solution" for B, deferred judgement on tiling pending their own investigation), propose starting
-with **Fix B** as a scoped, physically-motivated interim PR, explicitly flagging the residual
-single-albedo limitation as known-limitation / future-work (candidate follow-up: apply the same `G_g`/`G_s`
-partition idea to albedo, i.e. compute `R_net` twice with `α_ground`/`α_snow` and combine post-hoc, without
-going all the way to full turbulent-flux tiling — worth scoping as **Fix B+** if the investigation shows
-albedo blending is still a significant residual error after B).
+**Decision (rev 2): Fix B**, approved by the author. Run investigation steps 1, 2, and 4 first (mechanism
+confirmation is cheap and de-risks the implementation); step 3 is out of scope. The residual single-albedo
+limitation (point 4 of the Background section) is accepted as a known limitation for this PR, with
+**Fix B+** (post-hoc dual-albedo `R_net`) or full tiling (**Fix C**) as candidate future work if step 2 of
+the investigation shows it's still a significant residual error after B.
 
 ## Summary of changes
 

--- a/docs/src/processes/surface_energy/skin_temperature.md
+++ b/docs/src/processes/surface_energy/skin_temperature.md
@@ -25,23 +25,27 @@ where $R_{\text{net}}$ is the net radiation budget, $H_s$ is the sensible heat f
 ImplicitSkinTemperature
 ```
 
-Skin temperature can be determined instantaneously at each time step by finding the roots of the above nonlinear energy balance equation at each grid point. Given a trial skin temperature $T_s$, the **residual energy flux** required to close the energy balance is
+Skin temperature can be determined instantaneously at each time step by finding the roots of the above nonlinear energy balance equation at each grid point. Given a trial skin temperature $T_s$, the **demanded flux** required to close the energy balance is
 ```math
 G^\star = R_{\text{net}}(T_s) + H_s(T_s) + H_l(T_s)
 ```
-Correspondingly, the implied **conductive flux** between the skin and the ground surface (uppermost soil layer) at temperature $T_g$, across the half-cell of thickness $\Delta z_1 / 2$, is
+This demanded flux is equated to the area-weighted sum of two *unblended* conductive targets: the flux $G$ between the skin and the snow-free ground surface (uppermost soil layer) at temperature $T_g$, across the half-cell of thickness $\Delta z_1 / 2$,
 ```math
-G = \frac{2 \kappa_s}{\Delta z_1} (T_g - T_s)
+G(T_s, T_g) = \frac{2 \kappa_s}{\Delta z_1} (T_g - T_s)
 ```
-Setting the conductive flux equal to the residual energy flux and rearranging terms yields the skin temperature,
+and, over the snow-covered fraction $f_{\text{snow}}$, the flux $S$ between the skin and the top of the snowpack at temperature $T_{\text{snow}}$, across its (floored) depth $d_{\text{snow}}$,
 ```math
-T_s^\star = T_g - G^\star \frac{\Delta z_1}{2 \kappa_s}
+S(T_s, T_{\text{snow}}) = \frac{2 \kappa_{\text{snow}}}{d_{\text{snow}}} (T_{\text{snow}} - T_s)
 ```
-and the residual driving the nonlinear solve is the difference between the current and implied skin temperatures,
+Keeping $G$ and $S$ unblended (rather than averaging the ground and snow conduction targets into a single cell-wide target) prevents the flux delivered to a thin or patchy snowpack from being diluted by the bare-ground share. Setting the demanded flux equal to the area-weighted conductive fluxes and solving for $T_s$ (both conductive terms are affine in $T_s$, so this is an exact linear solve) yields
+```math
+T_s^\star = \frac{(1 - f_{\text{snow}}) \frac{2\kappa_s}{\Delta z_1} T_g + f_{\text{snow}} \frac{2\kappa_{\text{snow}}}{d_{\text{snow}}} T_{\text{snow}} - G^\star}{(1 - f_{\text{snow}}) \frac{2\kappa_s}{\Delta z_1} + f_{\text{snow}} \frac{2\kappa_{\text{snow}}}{d_{\text{snow}}}}
+```
+which reduces to $T_s^\star = T_g - G^\star \Delta z_1 / (2\kappa_s)$ without snow ($f_{\text{snow}} = 0$). The residual driving the nonlinear solve is the difference between the current and implied skin temperatures,
 ```math
 r(T_s) = T_s - T_s^\star
 ```
-The root $r(T_s) = 0$ is the skin temperature at which the conductive flux balances the radiative and turbulent fluxes, i.e. the solution of the surface energy balance.
+The root $r(T_s) = 0$ is the skin temperature at which the conductive fluxes balance the radiative and turbulent fluxes, i.e. the solution of the surface energy balance. Note that the *stored* `ground_heat_flux` field is not $G^\star$ but the explicit conductive flux $G(T_s, T_g)$ evaluated at the converged $T_s$ — the two coincide only at convergence (see [`compute_ground_heat_flux`](@ref)).
 
 The solve is performed by [`solve_skin_temperature!`](@ref), which wraps [`compute_skin_temperature_residual!`](@ref) in an [`ObjectiveFunction`](@ref) targeting the `skin_temperature` field and hands it to the configured solver. The default solver, [`default_skin_temperature_solver`](@ref), is a Newton-Raphson ([`RootSolver`](@ref) provided by [RootSolvers.jl](https://github.com/CliMA/RootSolvers.jl)) with a fixed iteration budget of $n = 5$ to balance accuracy with GPU efficiency. The prognostic `skin_temperature` is seeded with the current `ground_temperature` by [`initialize!`](@ref) so that the iteration starts from a physically sensible guess close to the root. After the solve converges, the surface energy fluxes are recomputed from the final skin temperature.
 
@@ -67,9 +71,7 @@ compute_auxiliary!(state, grid, skinT::ImplicitSkinTemperature, seb::AbstractSur
 ## Methods
 
 ```@docs; canonical = false
-compute_skin_temperature(::ImplicitSkinTemperature, Tg, G, Δz, κ)
-compute_ground_heat_flux(::AbstractSkinTemperature, R_net, H_s, H_l)
-compute_skin_temperature!(state, grid, skinT::ImplicitSkinTemperature, constants::PhysicalConstants, snow::Optional{AbstractSnow})
+compute_ground_heat_flux_demand(::AbstractSkinTemperature, R_net, H_s, H_l)
 compute_ground_heat_flux!(state, grid, skinT::AbstractSkinTemperature, seb::AbstractSurfaceEnergyBalance)
 default_skin_temperature_solver
 ```
@@ -77,10 +79,12 @@ default_skin_temperature_solver
 ## Kernel functions
 
 ```@docs; canonical = false
-compute_skin_temperature(i, j, grid, fields, skinT::ImplicitSkinTemperature, constants::PhysicalConstants, snow::Optional{AbstractSnow})
-compute_ground_heat_flux(i, j, grid, fields, skinT::AbstractSkinTemperature, ::AbstractSurfaceEnergyBalance)
+compute_ground_heat_flux_demand(i, j, grid, fields, skinT::AbstractSkinTemperature, ::AbstractSurfaceEnergyBalance)
+compute_ground_heat_flux(i, j, grid, fields, skinT::PrescribedSkinTemperature, seb::AbstractSurfaceEnergyBalance)
+compute_ground_heat_flux(i, j, grid, fields, skinT::ImplicitSkinTemperature, ::AbstractSurfaceEnergyBalance)
 compute_ground_heat_flux!(out, i, j, grid, fields, skinT::AbstractSkinTemperature, seb::AbstractSurfaceEnergyBalance)
-compute_skin_temperature!(out, i, j, grid, fields, skinT::ImplicitSkinTemperature, seb::AbstractSurfaceEnergyBalance, constants::PhysicalConstants, snow::Optional{AbstractSnow}, seb_args...)
+compute_skin_temperature(i, j, grid, fields, skinT::ImplicitSkinTemperature{NF}, args...) where {NF}
+compute_skin_temperature(i, j, grid, fields, skinT::ImplicitSkinTemperature{NF}, constants::PhysicalConstants, snow::AbstractSnow) where {NF}
 compute_skin_temperature_residual!
 solve_skin_temperature!
 ```

--- a/examples/simulations/speedy_wet_land.jl
+++ b/examples/simulations/speedy_wet_land.jl
@@ -135,6 +135,11 @@ Speedy.add!(primitive_wet_coupled.output, Speedy.PrecipitationOutput())
 Speedy.add!(primitive_wet_coupled.output, Speedy.SurfaceSensibleHeatFluxOutput())
 Speedy.add!(primitive_wet_coupled.output, Speedy.SurfaceHumidityFluxOutput())
 Speedy.add!(primitive_wet_coupled.output, Speedy.AlbedoOutput())
+Speedy.add!(primitive_wet_coupled.output, Speedy.TerrariumOutput(terrarium_model, :evaporation_ground))
+Speedy.add!(primitive_wet_coupled.output, Speedy.TerrariumOutput(terrarium_model, :evaporation_canopy))
+Speedy.add!(primitive_wet_coupled.output, Speedy.TerrariumOutput(terrarium_model, :transpiration))
+Speedy.add!(primitive_wet_coupled.output, Speedy.TerrariumOutput(terrarium_model, :sublimation))
+Speedy.add!(primitive_wet_coupled.output, Speedy.TerrariumOutput(terrarium_model, :gross_primary_production))
 
 # Initialize the coupled simulation
 @info "Initializing coupled simulation"
@@ -154,7 +159,7 @@ plot_land_field(land_state.horizon1.sand_fraction)
 plot_land_field(land_state.leaf_area_index)
 
 # Looks good! Let's run it!
-period = Month(3)
+period = Year(1)
 @info "Running simulation for $period"
 @time Speedy.run!(sim_coupled; period, output = true)
 
@@ -193,12 +198,3 @@ zs = on_architecture(CPU(), znodes(land_state.temperature))
 Makie.scatterlines(T, zs)
 Makie.scatterlines(sat, zs)
 Makie.scatterlines(f, zs)
-
-# Make some animations!
-sim_coupled_cpu = on_architecture(CPU(), sim_coupled)
-Speedy.animate(sim_coupled_cpu, output_file = "plots/speedy_terrarium_sd_animation.mp4", variable = "sd", framerate = 20, transient_timesteps = 1)
-Speedy.animate(sim_coupled_cpu, output_file = "plots/speedy_terrarium_tsoil_animation.mp4", variable = "st", framerate = 20, layer = 1, transient_timesteps = 1)
-Speedy.animate(sim_coupled_cpu, output_file = "plots/speedy_terrarium_tair_animation.mp4", variable = "temp", framerate = 20, layer = spectral_grid.nlayers, transient_timesteps = 1)
-Speedy.animate(sim_coupled_cpu, output_file = "plots/speedy_terrarium_shf_animation.mp4", variable = "shf", framerate = 20, transient_timesteps = 1)
-Speedy.animate(sim_coupled_cpu, output_file = "plots/speedy_terrarium_shuf_animation.mp4", variable = "shuf", framerate = 20, transient_timesteps = 1)
-Speedy.animate(sim_coupled_cpu, output_file = "plots/speedy_terrarium_snow_cond_animation.mp4", variable = "snow_cond", framerate = 20, transient_timesteps = 1)

--- a/src/diagnostics/surface_fluxes.jl
+++ b/src/diagnostics/surface_fluxes.jl
@@ -16,3 +16,55 @@ function diagnose_skin_temperature_residual(
         return Ts_prev - Ts_implicit
     end
 end
+
+"""
+    $TYPEDSIGNATURES
+
+Return a `KernelFunctionOperation` that computes the kinematic surface humidity flux [m/s] over all grid cells.
+"""
+diagnose_surface_humidity_flux(state, model::LandModel) =
+    diagnose_surface_humidity_flux(state, model, get_evapotranspiration(model.surface_hydrology), model.constants, model.atmosphere)
+
+function diagnose_surface_humidity_flux(
+        state,
+        model::AbstractModel,
+        evapotranspiration::AbstractEvapotranspiration,
+        constants::PhysicalConstants,
+        atmos::AbstractAtmosphere
+    )
+    return kernel_operation2D(compute_surface_humidity_flux, state, model.grid, evapotranspiration, constants, atmos)
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Return a `KernelFunctionOperation` that computes the evaporation flux [m/s liquid water] over all grid cells.
+The kinematic humidity flux is rescaled by the air-to-water density ratio and weighted by the snow-free area fraction.
+"""
+diagnose_evaporation_flux(state, model::LandModel) =
+    diagnose_evaporation_flux(state, model, get_evapotranspiration(model.surface_hydrology), model.constants, model.atmosphere, model.snow)
+
+function diagnose_evaporation_flux(
+        state,
+        model::AbstractModel,
+        evapotranspiration::AbstractEvapotranspiration,
+        constants::PhysicalConstants,
+        atmos::AbstractAtmosphere,
+        snow::Optional{AbstractSnow} = nothing
+    )
+    return kernel_operation2D(evaporation_flux, state, model.grid, evapotranspiration, constants, atmos, snow)
+end
+
+function evaporation_flux(
+        i, j, grid, fields,
+        evapotranspiration::AbstractEvapotranspiration,
+        constants::PhysicalConstants,
+        atmos::AbstractAtmosphere,
+        snow::Optional{AbstractSnow}
+    )
+    Qh = compute_surface_humidity_flux(i, j, grid, fields, evapotranspiration, constants, atmos)
+    ρ_a = air_density(i, j, grid, fields, atmos, constants)
+    ρ_w = constants.material.density_water
+    f_snow = snow_cover_fraction(i, j, grid, fields, snow)
+    return (1 - f_snow) * Qh * ρ_a / ρ_w
+end

--- a/src/diagnostics/surface_fluxes.jl
+++ b/src/diagnostics/surface_fluxes.jl
@@ -52,19 +52,18 @@ function diagnose_evaporation_flux(
         atmos::AbstractAtmosphere,
         snow::Optional{AbstractSnow} = nothing
     )
-    return kernel_operation2D(evaporation_flux, state, model.grid, evapotranspiration, constants, atmos, snow)
-end
-
-function evaporation_flux(
-        i, j, grid, fields,
-        evapotranspiration::AbstractEvapotranspiration,
-        constants::PhysicalConstants,
-        atmos::AbstractAtmosphere,
-        snow::Optional{AbstractSnow}
-    )
-    Qh = compute_surface_humidity_flux(i, j, grid, fields, evapotranspiration, constants, atmos)
-    ρ_a = air_density(i, j, grid, fields, atmos, constants)
-    ρ_w = constants.material.density_water
-    f_snow = snow_cover_fraction(i, j, grid, fields, snow)
-    return (1 - f_snow) * Qh * ρ_a / ρ_w
+    function surface_evapotranspiration_flux(
+            i, j, grid, fields,
+            evapotranspiration::AbstractEvapotranspiration,
+            constants::PhysicalConstants,
+            atmos::AbstractAtmosphere,
+            snow::Optional{AbstractSnow}
+        )
+        Qh = compute_surface_humidity_flux(i, j, grid, fields, evapotranspiration, constants, atmos)
+        ρ_a = air_density(i, j, grid, fields, atmos, constants)
+        ρ_w = constants.material.density_water
+        f_snow = snow_cover_fraction(i, j, grid, fields, snow)
+        return (1 - f_snow) * Qh * ρ_a / ρ_w
+    end
+    return kernel_operation2D(surface_evapotranspiration_flux, state, model.grid, evapotranspiration, constants, atmos, snow)
 end

--- a/src/models/coupled/land_model.jl
+++ b/src/models/coupled/land_model.jl
@@ -75,17 +75,26 @@ function StateVariables(
     # since fluxes are by convention positive upwards
     infiltration_bc = InfiltrationFlux(-infiltration)
     bcs = merge_boundary_conditions(boundary_conditions, soil_heat_flux_bc, infiltration_bc)
+    # The snow-top conductive flux (drives the snowpack's own energy tendency) is a genuinely distinct
+    # quantity from the bare-ground `ground_heat_flux` once snow is present (see `skin_temperature.jl`'s
+    # per-fraction `G`/`S` split), so it gets its own field rather than aliasing `ground_heat_flux`.
+    snow_surface_heat_flux = if isnothing(model.snow)
+        ground_heat_flux
+    else
+        initialize(vars.snow_surface_heat_flux, grid, clock, fields, boundary_conditions)
+    end
     # The snow energy tendency reads its boundary heat fluxes from the `surface_heat_flux`/`basal_heat_flux`
-    # input fields; alias them to the surface energy balance closure flux (`ground_heat_flux`) and the
+    # input fields; alias them to the snow-top conductive flux (`snow_surface_heat_flux`) and the
     # blended soil-top flux (`soil_heat_flux`) so no additional state fields are allocated (no-op without snow).
-    snow_flux_aliases = isnothing(model.snow) ? (;) : (; surface_heat_flux = ground_heat_flux, basal_heat_flux = soil_heat_flux)
+    snow_flux_aliases = isnothing(model.snow) ? (;) : (; surface_heat_flux = snow_surface_heat_flux, basal_heat_flux = soil_heat_flux)
     # Merge user-defined fields with BC fields
-    fields = merge((; ground_heat_flux, infiltration, soil_heat_flux), snow_flux_aliases, fields)
+    fields = merge((; ground_heat_flux, infiltration, soil_heat_flux, snow_surface_heat_flux), snow_flux_aliases, fields)
     return StateVariables(vars, grid; clock, timestepper = get_timestepper(model), model, boundary_conditions = bcs, fields)
 end
 
 interface_variables(::LandModel) = (
     auxiliary(:soil_heat_flux, XY(); units = u"W/m^2", desc = "Blended heat flux into the soil top (snow base + bare ground)"),
+    auxiliary(:snow_surface_heat_flux, XY(); units = u"W/m^2", desc = "Conductive heat flux from the skin into the top of the snowpack (positive upward); drives the snowpack's own energy tendency"),
 )
 
 function initialize!(state, model::LandModel)

--- a/src/processes/processes.jl
+++ b/src/processes/processes.jl
@@ -79,20 +79,26 @@ include("soil/soil_diffusion_timescales.jl")
 
 export ConstantSnowHydraulics
 include("snow/snow_hydraulic_properties.jl")
+
 export SingleLayerSnow
 include("snow/snow_single_layer.jl")
 include("snow/snow_interfaces.jl")
 include("snow/snow_albedo.jl")
+
 export FractionalSnowCover
 include("snow/mass/snow_cover.jl")
+
 export ConstantSnowDensity
 include("snow/mass/snow_density.jl")
 include("snow/mass/snow_mass.jl")
+
 export PowerLawSnowThermalConductivity, LogarithmicSnowThermalConductivity, QuadraticSnowThermalConductivity
 include("snow/energy/snow_thermal_conductivity.jl")
+
 export SnowEnergyTemperatureClosure
 include("snow/energy/snow_energy_closures.jl")
 include("snow/energy/snow_energy.jl")
+include("snow/snow_diffusion_timescales.jl")
 
 # Vegetation
 

--- a/src/processes/snow/energy/snow_energy.jl
+++ b/src/processes/snow/energy/snow_energy.jl
@@ -117,27 +117,12 @@ end
 
 Volumetric snow internal energy `U_snow = Ū_snow/max(d_snow, d_min)` [J/m³] from the depth-integrated
 energy `Ū_snow` [J/m²] and the snow depth `d_snow` [m]. The depth is floored at the minimum thermal
-thickness `d_min` (see [`SingleLayerSnow`](@ref)'s `min_conduction_thickness`) rather than a machine-`eps`
-offset. This bounds the snow temperature recovered downstream: with only an `eps` offset, any residual
-`Ū_snow` over a vanishing `d_snow` gives a huge `U_snow` and hence a snow temperature far below physical
-bounds, which then corrupts the (cover-fraction-blended) skin temperature and basal heat flux. Flooring
-at `d_min` gives a thin snowpack a bounded effective heat capacity `C_snow·d_min`, so it stores
-negligible energy and is thermally transient — the ground heat flux passes essentially unmediated to the
-soil (`f_snow → 0` in the blend) while the pack still stores mass and modifies the surface albedo.
+thickness `d_min` (see [`min_snow_conduction_thickness`](@ref)) rather than a machine-`eps` offset. This
+bounds the snow temperature recovered downstream: with only an `eps` offset, any residual `Ū_snow` over
+a vanishing `d_snow` gives a huge `U_snow` and hence a snow temperature far below physical bounds, which
+then corrupts the (cover-fraction-blended) skin temperature and basal heat flux. Flooring at `d_min`
+gives a thin snowpack a bounded effective heat capacity `C_snow·d_min`, so it stores negligible energy
+and is thermally transient — the ground heat flux passes essentially unmediated to the soil
+(`f_snow → 0` in the blend) while the pack still stores mass and modifies the surface albedo.
 """
 @inline compute_snow_volumetric_energy(Ū_snow::NF, d_snow::NF, d_min::NF) where {NF} = Ū_snow / max(d_snow, d_min)
-
-"""
-    $TYPEDSIGNATURES
-
-Snow→soil basal conductive heat flux `Q_base` [W/m²], positive upward (soil → snow). The snowpack is a
-strong insulator, so only its resistance is retained (snow-resistance-only closure):
-`Q_base = 2·κ_snow·(T_soil − T_snow)/max(d_snow, d_min)`. The conduction thickness is floored at the
-minimum thickness `d_min` (see [`SingleLayerSnow`](@ref)'s `min_conduction_thickness`) rather than a
-machine-`eps` offset: as `d_snow → 0` the snow→soil conduction time constant `τ ∝ d_snow` collapses,
-so an `eps` floor still permits an unbounded (relative to the vanishing snow heat capacity) basal flux
-that destabilizes explicit time-stepping and can drive the snow temperature far below physical bounds.
-Flooring at a physically meaningful `d_min` bounds `τ` from below and keeps the flux finite.
-"""
-@inline compute_snow_basal_heat_flux(κ_snow::NF, T_soil::NF, T_snow::NF, d_snow::NF, d_min::NF) where {NF} =
-    2 * κ_snow * (T_soil - T_snow) / max(d_snow, d_min)

--- a/src/processes/snow/energy/snow_energy.jl
+++ b/src/processes/snow/energy/snow_energy.jl
@@ -75,6 +75,17 @@ carried by the departing vapor.
 Note that no explicit *meltwater* energy term appears because meltwater drains as liquid water at 0 °C,
 which is the zero-enthalpy reference (`U = 0`) of the `FreeWater` closure, so it carries no enthalpy
 out of the snowpack.
+
+The conductive/sublimation terms `Q_base - Q_top + Q_subl` are gated to zero when the pack is empty at
+the *start* of the step (`W == 0`), since they are otherwise evaluated against a degenerate zero-depth
+layer (`Q_top`/`Q_base` conduction targets floored at `min_conduction_thickness`, giving an arbitrarily
+large flux relative to a genuinely-thin pack's tiny heat capacity). `Q_prcp` is *not* gated: it is a pure
+source term from the precipitation rate alone, well-defined regardless of the existing pack depth. Gating
+it too — as a previous implementation did, multiplying the whole `dUdt` including `Q_prcp` by `W > 0` —
+zeroed the energy input on the very first step any snow accumulates onto bare ground (`W` is read before
+that step's mass increment), leaving the freshly-fallen, physically cold snow with zero recorded
+enthalpy. Under the `FreeWater` closure (`U = 0` ≡ liquid water at 0 °C) that reads as instantaneously
+fully melted, triggering spurious immediate Darcy drainage regardless of how cold the air actually was.
 """
 @propagate_inbounds function compute_snow_energy_tendency(
         i, j, grid, fields,
@@ -95,8 +106,8 @@ out of the snowpack.
     R_snow = f_snow * R
     Q_prcp = compute_snow_precip_heat_flux(snow, constants, P_s, R_snow, T_air)
     Q_subl = ρ_w * L_sl * E_subl # correction to account for enthalpy of lost ice
-    dUdt = Q_base - Q_top + Q_prcp + Q_subl
-    return dUdt * (W > 0) # the W > 0 gate *should* be unnecessary but is included just in case
+    dUdt = (Q_base - Q_top + Q_subl) * (W > 0) + Q_prcp
+    return dUdt
 end
 
 # Helper functions

--- a/src/processes/snow/energy/snow_energy_closures.jl
+++ b/src/processes/snow/energy/snow_energy_closures.jl
@@ -106,13 +106,15 @@ Recover the snow temperature and liquid water fraction from the depth-integrated
     d_snow = compute_snow_depth(snow, W_snow, ρ_snow, ρ_w)
     # Volumetric latent heat of fusion
     ρLθ = ρ_snow * L_sl # ρ_snow L_sl = ρ_w θ L_sl by definition
-    U_snow = compute_snow_volumetric_energy(Ū_snow, d_snow, snow.min_conduction_thickness)
-    liq = liquid_water_fraction(FreeWater(), U_snow, ρLθ)
+    # Compute liquid water fraction from depth-integrated energy and latent heat of fusion
+    liq = liquid_water_fraction(FreeWater(), Ū_snow, d_snow * ρLθ)
+    # liq will be 1 for W_snow = 0, so gate by W_snow > 0
     out.snow_liquid_fraction[i, j, 1] = liq * (W_snow > 0)
-    C_snow = compute_snow_volumetric_heat_capacity(snow, constants, ρ_snow, liq)
     # Snow temperature cannot exceed 0°C, so clip the free-water temperature at zero. The energy above
     # the fully-melted (0°C, all-liquid) reference, i.e. the positive part `U_snow > 0`, is not stored; it
     # is derived on demand where needed to determine snow melt.
+    C_snow = compute_snow_volumetric_heat_capacity(snow, constants, ρ_snow, liq)
+    U_snow = compute_snow_volumetric_energy(Ū_snow, d_snow, snow.min_conduction_thickness)
     T = energy_to_temperature(FreeWater(), U_snow, ρLθ, C_snow)
     out.snow_temperature[i, j, 1] = min(T, zero(T))
     return nothing

--- a/src/processes/snow/energy/snow_energy_closures.jl
+++ b/src/processes/snow/energy/snow_energy_closures.jl
@@ -114,7 +114,7 @@ Recover the snow temperature and liquid water fraction from the depth-integrated
     # the fully-melted (0°C, all-liquid) reference, i.e. the positive part `U_snow > 0`, is not stored; it
     # is derived on demand where needed to determine snow melt.
     C_snow = compute_snow_volumetric_heat_capacity(snow, constants, ρ_snow, liq)
-    U_snow = compute_snow_volumetric_energy(Ū_snow, d_snow, snow.min_conduction_thickness)
+    U_snow = compute_snow_volumetric_energy(Ū_snow, d_snow, min_snow_conduction_thickness(i, j, grid, fields, snow))
     T = energy_to_temperature(FreeWater(), U_snow, ρLθ, C_snow)
     out.snow_temperature[i, j, 1] = min(T, zero(T))
     return nothing

--- a/src/processes/snow/snow_diffusion_timescales.jl
+++ b/src/processes/snow/snow_diffusion_timescales.jl
@@ -1,0 +1,48 @@
+#####
+##### Snow heat diffusion timescale
+#####
+
+# Fallback: no snow ⇒ no additional diffusive restriction.
+cell_diffusion_timescale(state, grid, ::Nothing, constants::PhysicalConstants) = convert(eltype(grid), Inf)
+
+"""
+    $TYPEDSIGNATURES
+
+Return the minimum thermal diffusion timescale ``τ = \\max(d_{\\text{snow}}, d_{\\text{min}})² \\,
+C_{\\text{snow}} / κ_{\\text{snow}}`` over the grid for the snow-top conduction operator, mirroring
+the [`cell_diffusion_timescale`](@ref) pattern used for soil. Uses the same floored conduction thickness
+([`min_snow_conduction_thickness`](@ref)) that enters the actual conductive-flux calculations
+([`compute_snow_surface_heat_flux`](@ref), [`compute_snow_basal_heat_flux`](@ref)), so the reported
+timescale reflects the stability limit of the discretization as implemented — the floor bounds it below
+for a vanishing pack, while a genuinely thick pack still reports its own (longer, less restrictive)
+timescale rather than being pinned to the floor.
+"""
+function cell_diffusion_timescale(state, grid, snow::SingleLayerSnow, constants::PhysicalConstants)
+    field_grid = get_field_grid(grid)
+    fields = get_fields(state, snow)
+    τ = KernelFunctionOperation{Center, Center, Nothing}(
+        compute_snow_diffusion_timescale, field_grid, fields, snow, constants
+    )
+    return minimum(τ)
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Kernel function returning the snow thermal diffusion timescale ``\\max(d_{\\text{snow}}, d_{\\text{min}})²
+\\, C_{\\text{snow}} / κ_{\\text{snow}}`` at grid cell `i, j`, with the bulk thermal conductivity and heat
+capacity computed from the local snow density and liquid fraction.
+"""
+@inline @propagate_inbounds function compute_snow_diffusion_timescale(
+        i, j, grid, fields,
+        snow::SingleLayerSnow,
+        constants::PhysicalConstants
+    )
+    ρ_snow = compute_snow_density(i, j, grid, fields, snow.density)
+    κ_snow = compute_thermal_conductivity(snow, constants.material, ρ_snow)
+    liq = fields.snow_liquid_fraction[i, j]
+    C_snow = compute_snow_volumetric_heat_capacity(snow, constants, ρ_snow, liq)
+    d_snow = max(snow_depth(i, j, grid, fields, snow), min_snow_conduction_thickness(i, j, grid, fields, snow))
+    # thermal diffusivity α = κ / C ⟹ τ = d_snow² / α = d_snow² C / κ
+    return d_snow^2 * C_snow / κ_snow
+end

--- a/src/processes/snow/snow_interfaces.jl
+++ b/src/processes/snow/snow_interfaces.jl
@@ -2,10 +2,11 @@
     $TYPEDSIGNATURES
 
 Launch [`compute_snow_interface_fluxes!`](@ref) to diagnose the snow↔surface/soil coupling fluxes from the
-snow state and the surface energy balance outputs: the blended soil-top heat flux (`soil_heat_flux`) and
-the snow surface sublimation rate (`sublimation`, the snow-fraction bulk-aerodynamic vapor flux at the
-converged skin temperature). Must run after the surface energy balance (which sets `ground_heat_flux` and
-the skin temperature). No-op when there is no snowpack (`snow === nothing`).
+snow state and the surface energy balance outputs: the blended soil-top heat flux (`soil_heat_flux`), the
+snow-top conductive flux (`surface_heat_flux`, drives the snowpack's own energy tendency), and the snow
+surface sublimation rate (`sublimation`, the snow-fraction bulk-aerodynamic vapor flux at the converged
+skin temperature). Must run after the surface energy balance (which sets `ground_heat_flux` and the skin
+temperature). No-op when there is no snowpack (`snow === nothing`).
 """
 compute_snow_interface_fluxes!(state, grid, ::Nothing, args...) = nothing
 function compute_snow_interface_fluxes!(
@@ -20,6 +21,7 @@ function compute_snow_interface_fluxes!(
     out = (
         sublimation = state.sublimation,
         basal_heat_flux = state.basal_heat_flux,
+        surface_heat_flux = state.surface_heat_flux,
     )
     fields = get_fields(state, snow, seb, soil, atmos)
     launch!(grid, XY, compute_snow_interface_fluxes_kernel!, out, fields, snow, seb, soil, constants, atmos)
@@ -30,9 +32,11 @@ end
     $TYPEDSIGNATURES
 
 Blended soil-top heat flux [W/m²] at grid cell `i, j`: the snow-cover-fraction-weighted combination of
-the snow→soil basal conductive flux `Q_base` and the bare-ground surface energy balance closure flux `G`
-(`ground_heat_flux`), `f_snow·Q_base + (1 − f_snow)·G`. The bulk snow thermal conductivity entering
-`Q_base` is recovered lazily from the density scheme rather than stored.
+the snow→soil basal conductive flux `Q_base` and the *explicit* bare-ground conductive flux `G`
+(`ground_heat_flux`, already the unblended per-bare-ground-area quantity — see the
+`ImplicitSkinTemperature`-specific `compute_ground_heat_flux` in `skin_temperature.jl`),
+`f_snow·Q_base + (1 − f_snow)·G`. The bulk snow thermal conductivity entering `Q_base` is recovered
+lazily from the density scheme rather than stored.
 """
 @propagate_inbounds function compute_snow_soil_heat_flux(
         i, j, grid, fields,
@@ -54,10 +58,32 @@ end
 """
     $TYPEDSIGNATURES
 
+Snow-top conductive heat flux [W/m²] at grid cell `i, j` (positive upward, i.e. energy leaving the snow
+top into the skin), `S = 2κ_snow(T_snow − T_skin)/max(d_snow, d_min)` — the same unblended snow
+conduction target the skin-temperature solve closes against (see
+[`Terrarium.snow_conduction_interface`](@ref)). This is the per-unit-snow-area flux that drives the
+snowpack's own top-of-pack energy tendency ([`compute_snow_energy_tendency`](@ref)'s `Q_top`); it replaces
+a previous unweighted alias to the whole-grid-cell `ground_heat_flux`, which forced the entire snowpack
+with a flux sized for the whole cell regardless of how small the snow-covered fraction actually was.
+"""
+@propagate_inbounds function compute_snow_surface_heat_flux(
+        i, j, grid, fields,
+        snow::SingleLayerSnow,
+        constants::PhysicalConstants
+    )
+    T_snow, κ_snow, d_snow = snow_conduction_interface(i, j, grid, fields, snow, constants)
+    Ts = fields.skin_temperature[i, j]
+    return 2 * κ_snow * (T_snow - Ts) / d_snow
+end
+
+"""
+    $TYPEDSIGNATURES
+
 Diagnose the snow↔surface/soil coupling fluxes at grid cell `i, j`, run after the surface energy balance:
-the blended soil-top heat flux (see [`compute_snow_soil_heat_flux`](@ref)) and the snow surface
-sublimation rate (see [`compute_snow_sublimation_flux`](@ref), the same snow-fraction vapor flux the
-surface energy balance uses for the latent-flux partition).
+the blended soil-top heat flux (see [`compute_snow_soil_heat_flux`](@ref)), the snow-top conductive flux
+(see [`compute_snow_surface_heat_flux`](@ref)), and the snow surface sublimation rate (see
+[`compute_snow_sublimation_flux`](@ref), the same snow-fraction vapor flux the surface energy balance uses
+for the latent-flux partition).
 """
 @propagate_inbounds function compute_snow_interface_fluxes!(
         out, i, j, grid, fields,
@@ -71,6 +97,7 @@ surface energy balance uses for the latent-flux partition).
     E_subl = compute_snow_sublimation_flux(i, j, grid, fields, snow, atmos, constants, seb.skin_temperature)
     out.sublimation[i, j, 1] = f * E_subl
     out.basal_heat_flux[i, j, 1] = compute_snow_soil_heat_flux(i, j, grid, fields, snow, constants, soil)
+    out.surface_heat_flux[i, j, 1] = compute_snow_surface_heat_flux(i, j, grid, fields, snow, constants)
     return nothing
 end
 

--- a/src/processes/snow/snow_interfaces.jl
+++ b/src/processes/snow/snow_interfaces.jl
@@ -61,7 +61,7 @@ end
 Snow-top conductive heat flux [W/m²] at grid cell `i, j` (positive upward, i.e. energy leaving the snow
 top into the skin), `S = 2κ_snow(T_snow − T_skin)/max(d_snow, d_min)` — the same unblended snow
 conduction target the skin-temperature solve closes against (see
-[`Terrarium.snow_conduction_interface`](@ref)). This is the per-unit-snow-area flux that drives the
+[`Terrarium.snow_thermal_interface`](@ref)). This is the per-unit-snow-area flux that drives the
 snowpack's own top-of-pack energy tendency ([`compute_snow_energy_tendency`](@ref)'s `Q_top`); it replaces
 a previous unweighted alias to the whole-grid-cell `ground_heat_flux`, which forced the entire snowpack
 with a flux sized for the whole cell regardless of how small the snow-covered fraction actually was.
@@ -71,7 +71,7 @@ with a flux sized for the whole cell regardless of how small the snow-covered fr
         snow::SingleLayerSnow,
         constants::PhysicalConstants
     )
-    T_snow, κ_snow, d_snow = snow_conduction_interface(i, j, grid, fields, snow, constants)
+    T_snow, κ_snow, d_snow = snow_thermal_interface(i, j, grid, fields, snow, constants)
     Ts = fields.skin_temperature[i, j]
     return 2 * κ_snow * (T_snow - Ts) / d_snow
 end

--- a/src/processes/snow/snow_interfaces.jl
+++ b/src/processes/snow/snow_interfaces.jl
@@ -31,12 +31,50 @@ end
 """
     $TYPEDSIGNATURES
 
+Snow→soil basal conductive heat flux `Q_base` [W/m²] at grid cell `i, j`, positive upward (soil → snow),
+as the series-resistance conduction between the soil's top half-cell and the snow layer:
+`Q_base = (T_soil − T_snow) / (Δz_soil/(2κ_soil) + d_snow/(2κ_snow))`. Both the local soil top-layer
+thermal conductivity `κ_soil` and the snow conductivity `κ_snow` are recovered from their respective
+composition/density schemes rather than stored. The snow-side conduction thickness is floored at
+[`min_snow_conduction_thickness`](@ref) as `d_snow → 0`, matching the floor used elsewhere in the snow
+thermodynamics; without the soil-side term this reduces to the previous snow-resistance-only closure,
+which is only valid once the soil resistance is genuinely negligible next to the (floored) snow's.
+"""
+@propagate_inbounds function compute_snow_basal_heat_flux(
+        i, j, grid, fields,
+        snow::SingleLayerSnow,
+        soil::AbstractSoil,
+        constants::PhysicalConstants
+    )
+    strat = get_stratigraphy(soil)
+    hydrology = get_hydrology(soil)
+    bgc = get_biogeochemistry(soil)
+    energy = get_energy_balance(soil)
+    field_grid = get_field_grid(grid)
+    k = field_grid.Nz
+    composition = soil_composition(i, j, k, grid, fields, strat, hydrology, bgc)
+    κ_soil = compute_thermal_conductivity(energy.thermal_properties, composition)
+    Δz_soil = Δzᵃᵃᶜ(i, j, k, field_grid)
+
+    ρ_snow = compute_snow_density(i, j, grid, fields, snow.density)
+    κ_snow = compute_thermal_conductivity(snow, constants.material, ρ_snow)
+    d_snow = max(fields.snow_depth[i, j], min_snow_conduction_thickness(i, j, grid, fields, snow))
+
+    T_soil = fields.ground_temperature[i, j]
+    T_snow = fields.snow_temperature[i, j]
+    R_soil = Δz_soil / (2 * κ_soil)
+    R_snow = d_snow / (2 * κ_snow)
+    return (T_soil - T_snow) / (R_soil + R_snow)
+end
+
+"""
+    $TYPEDSIGNATURES
+
 Blended soil-top heat flux [W/m²] at grid cell `i, j`: the snow-cover-fraction-weighted combination of
-the snow→soil basal conductive flux `Q_base` and the *explicit* bare-ground conductive flux `G`
-(`ground_heat_flux`, already the unblended per-bare-ground-area quantity — see the
-`ImplicitSkinTemperature`-specific `compute_ground_heat_flux` in `skin_temperature.jl`),
-`f_snow·Q_base + (1 − f_snow)·G`. The bulk snow thermal conductivity entering `Q_base` is recovered
-lazily from the density scheme rather than stored.
+the snow→soil basal conductive flux `Q_base` (see [`compute_snow_basal_heat_flux`](@ref)) and the
+*explicit* bare-ground conductive flux `G` (`ground_heat_flux`, already the unblended per-bare-ground-area
+quantity — see the `ImplicitSkinTemperature`-specific `compute_ground_heat_flux` in `skin_temperature.jl`),
+`f_snow·Q_base + (1 − f_snow)·G`.
 """
 @propagate_inbounds function compute_snow_soil_heat_flux(
         i, j, grid, fields,
@@ -46,12 +84,7 @@ lazily from the density scheme rather than stored.
     )
     G = fields.ground_heat_flux[i, j]
     f = fields.snow_cover_fraction[i, j]
-    d_snow = fields.snow_depth[i, j]
-    T_snow = fields.snow_temperature[i, j]
-    T_soil = fields.ground_temperature[i, j]
-    ρ_snow = compute_snow_density(i, j, grid, fields, snow.density)
-    κ_snow = compute_thermal_conductivity(snow, constants.material, ρ_snow)
-    Q_base = compute_snow_basal_heat_flux(κ_snow, T_soil, T_snow, d_snow, snow.min_conduction_thickness)
+    Q_base = compute_snow_basal_heat_flux(i, j, grid, fields, snow, soil, constants)
     return f * Q_base + (one(f) - f) * G
 end
 

--- a/src/processes/snow/snow_single_layer.jl
+++ b/src/processes/snow/snow_single_layer.jl
@@ -32,9 +32,6 @@ $FIELDS
 
     "Snow energy-temperature closure"
     @component closure::Closure
-
-    "Minimum snow thickness (m) used to regularize the thermodynamics for thin snowpacks"
-    @param min_conduction_thickness::NF (units = u"m", bounds = Positive)
 end
 
 function SingleLayerSnow(
@@ -45,13 +42,25 @@ function SingleLayerSnow(
         hydraulic_properties = ConstantSnowHydraulics(NF),
         albedo = ConstantSnowAlbedo(NF),
         closure = SnowEnergyTemperatureClosure(NF),
-        min_conduction_thickness::NF = NF(5.0e-3),
     ) where {NF}
-    # `NF` is only carried by the `min_conduction_thickness` scalar, so the remaining type parameters
-    # are supplied explicitly from the component types
+    # No field is directly typed `NF` (the minimum conduction thickness is now derived from the grid
+    # rather than stored, see `min_snow_conduction_thickness`), so `NF` is supplied explicitly here and
+    # carried only via the `AbstractSnow{NF}` supertype bound, mirroring `LandModel`/`SnowModel`.
     return SingleLayerSnow{NF, typeof(cover), typeof(density), typeof(thermal_conductivity), typeof(hydraulic_properties), typeof(albedo), typeof(closure)}(
-        cover, density, thermal_conductivity, hydraulic_properties, albedo, closure, min_conduction_thickness
+        cover, density, thermal_conductivity, hydraulic_properties, albedo, closure
     )
+end
+
+"""
+    $TYPEDSIGNATURES
+
+Minimum snow thickness (m) used to regularize the snow thermodynamics (conductive fluxes and the
+volumetric energy/temperature closure) as the pack thins toward zero: half the thickness of the
+uppermost soil grid cell, so the floor scales with the grid resolution rather than a fixed constant.
+"""
+@propagate_inbounds function min_snow_conduction_thickness(i, j, grid, fields, ::SingleLayerSnow)
+    field_grid = get_field_grid(grid)
+    return Δzᵃᵃᶜ(i, j, field_grid.Nz, field_grid) / 2
 end
 
 # Top-level interface

--- a/src/processes/surface/skin_temperature.jl
+++ b/src/processes/surface/skin_temperature.jl
@@ -49,13 +49,7 @@ snow-free ground (``T_g`` its temperature), ``S`` is the conductive flux from th
 snowpack over the snow-covered fraction (``T_{\\text{snow}}`` its temperature), and ``f_{\\text{snow}}``
 is the snow-covered area fraction (``f_{\\text{snow}} = 0`` and ``S`` absent without snow). ``G`` and
 ``S`` are each computed from their own *unblended* conduction target (see
-[`ground_thermal_interface`](@ref) and [`snow_conduction_interface`](@ref)) rather than a single
-cover-fraction-weighted blend of ground and snow properties — this keeps the flux delivered to the
-snow-covered fraction from being diluted (or, for small ``f_{\\text{snow}}``, from being replaced
-outright) by the bare-ground share when computing the snowpack's own top-of-pack energy tendency (see
-[`compute_skin_temperature_residual!`](@ref)). All fluxes follow the positive upwards convention: for
-``G`` and ``S``, this means from the medium below towards the surface is positive; for the other fluxes,
-this means from the surface towards the atmosphere is positive.
+[`ground_thermal_interface`](@ref) and [`snow_thermal_interface`](@ref)).
 
 Properties:
 $FIELDS
@@ -84,17 +78,6 @@ end
 """
     $TYPEDSIGNATURES
 
-Seed the prognostic `skin_temperature` with the current `ground_temperature` so the implicit
-nonlinear solve starts from a physically sensible guess close to the root.
-"""
-function initialize!(state, grid, ::ImplicitSkinTemperature, args...)
-    set!(state.skin_temperature, state.ground_temperature)
-    return nothing
-end
-
-"""
-    $TYPEDSIGNATURES
-
 Return the conduction target `(Tg, κ, Δz)` for the snow-free ground: the uppermost ground layer's
 `ground_temperature`, the assumed surface conductivity `κₛ`, and the top ground cell thickness. This is
 always the *unblended* ground-only target, used both when there is no snow and (weighted by
@@ -112,31 +95,29 @@ end
 
 Return the conduction target `(Tsnow, κsnow, dsnow)` for the snow-covered fraction: the snow's own
 (bulk) temperature, its thermal conductivity recovered from the density scheme, and its depth floored at
-`min_conduction_thickness` (avoids a `0/0` conductance as the pack vanishes — the same floor already used
-for the snow-base flux, see [`compute_snow_basal_heat_flux`](@ref)). Without snow (`snow === nothing`)
-returns a finite placeholder (`κsnow = 0`) so the always-zero `f_snow` weight in
-[`compute_skin_temperature_residual!`](@ref) eliminates this term without risking `0 * Inf = NaN`.
+`min_conduction_thickness`. Without snow (`snow === nothing`), returns a placeholders with `κsnow = 0`
+such that the snow conductive heat flux reduces to zero.
 """
-@propagate_inbounds snow_conduction_interface(i, j, grid, fields, ::Nothing, constants::PhysicalConstants) =
-    (zero(eltype(grid)), zero(eltype(grid)), one(eltype(grid)))
-@propagate_inbounds function snow_conduction_interface(i, j, grid, fields, snow::AbstractSnow, constants::PhysicalConstants)
+@propagate_inbounds function snow_thermal_interface(i, j, grid, fields, snow::AbstractSnow, constants::PhysicalConstants)
     ρ_snow = compute_snow_density(i, j, grid, fields, snow.density)
     κ_snow = compute_thermal_conductivity(snow, constants.material, ρ_snow)
     T_snow = snow_temperature(i, j, grid, fields, snow)
     d_snow = max(snow_depth(i, j, grid, fields, snow), snow.min_conduction_thickness)
     return (T_snow, κ_snow, d_snow)
 end
+# Fallback for case where snow == nothing
+@propagate_inbounds snow_thermal_interface(i, j, grid, fields, ::Nothing, constants::PhysicalConstants) = (zero(eltype(grid)), zero(eltype(grid)), one(eltype(grid)))
 
 """
     $TYPEDSIGNATURES
 
-Compute the ground heat flux `G` that closes the surface energy balance. With all fluxes
+Compute the residual ground heat flux that would close the surface energy balance. With all fluxes
 positive upward (aligned with `+z`), the energy arriving at the skin from below must balance
 the radiative and turbulent losses above, so `G = R_net + H_s + H_l`.
 """
-@inline function compute_ground_heat_flux(::AbstractSkinTemperature, R_net, H_s, H_l)
-    G = R_net + H_s + H_l
-    return G
+@inline function compute_ground_heat_flux_demand(::AbstractSkinTemperature, R_net, H_s, H_l)
+    G₀ = R_net + H_s + H_l
+    return G₀
 end
 
 ## Top-level interface methods
@@ -146,6 +127,17 @@ variables(::ImplicitSkinTemperature) = (
     auxiliary(:ground_heat_flux, XY(), units = u"W/m^2", desc = "Ground heat flux"),
     input(:ground_temperature, XY(), units = u"°C", desc = "Temperature of the uppermost ground or soil grid cell in °C"),
 )
+
+"""
+    $TYPEDSIGNATURES
+
+Seed the prognostic `skin_temperature` with the current `ground_temperature` so the implicit
+nonlinear solve starts from a physically sensible guess close to the root.
+"""
+function initialize!(state, grid, ::ImplicitSkinTemperature, args...)
+    set!(state.skin_temperature, state.ground_temperature)
+    return nothing
+end
 
 """ $TYPEDSIGNATURES """
 @inline function compute_auxiliary!(
@@ -161,7 +153,10 @@ end
 """
     $TYPEDSIGNATURES
 
-Compute `ground_heat_flux` as the residual ``R_\\text{net} + H_s + H_l`` (all fluxes positive upward).
+Compute and store `ground_heat_flux` on `grid`, dispatching on `skinT` to the type-specific kernel
+function: the atmosphere-side demand ``R_\\text{net} + H_s + H_l`` for [`PrescribedSkinTemperature`](@ref)
+(which has no separate conduction target), or the explicit conductive flux ``2\\kappa_g(T_g - T_s)/\\Delta z_g``
+for [`ImplicitSkinTemperature`](@ref) (all fluxes positive upward).
 """
 function compute_ground_heat_flux!(
         state, grid,
@@ -179,15 +174,10 @@ end
 """
     $TYPEDSIGNATURES
 
-Compute the ground heat flux from the surface net radiation and sensible/latent heat flux at grid cell
-`i, j`: the flux the atmosphere-side physics *demands* of the surface, `G = R_net + H_s + H_l`. This is
-the generic definition used directly by [`PrescribedSkinTemperature`](@ref) (which has no separate
-conduction target to solve against, so the demanded and stored fluxes coincide by construction) and,
-internally, as the atmosphere-side term of the [`ImplicitSkinTemperature`](@ref) residual (see
-[`compute_skin_temperature_residual!`](@ref)) — but *not* as `ImplicitSkinTemperature`'s own
-`ground_heat_flux` (see the more specific method below).
+Compute the ground heat flux *demand* from the surface net radiation and sensible/latent heat flux at grid cell
+`i, j`: i.e. the flux implied by the radiative budget and turbulent fluxes, `G = R_net + H_s + H_l`.
 """
-@propagate_inbounds function compute_ground_heat_flux(
+@propagate_inbounds function compute_ground_heat_flux_demand(
         i, j, grid, fields,
         skinT::AbstractSkinTemperature,
         ::AbstractSurfaceEnergyBalance
@@ -197,21 +187,28 @@ internally, as the atmosphere-side term of the [`ImplicitSkinTemperature`](@ref)
     H_s = fields.sensible_heat_flux[i, j]
     H_l = fields.latent_heat_flux[i, j]
     # Compute ground heat flux
-    G = compute_ground_heat_flux(skinT, R_net, H_s, H_l)
-    return G
+    G₀ = compute_ground_heat_flux_demand(skinT, R_net, H_s, H_l)
+    return G₀
+end
+
+
+"""
+    $TYPEDSIGNATURES
+
+For `PrescribedSkinTemperature`, set the ground heat flux directly to the demand, i.e. `G₀ = R_net + H_s + H_l`.
+"""
+@propagate_inbounds function compute_ground_heat_flux(
+        i, j, grid, fields,
+        skinT::PrescribedSkinTemperature,
+        seb::AbstractSurfaceEnergyBalance
+    )
+    return compute_ground_heat_flux_demand(i, j, grid, fields, skinT, seb)
 end
 
 """
     $TYPEDSIGNATURES
 
-`ImplicitSkinTemperature`'s `ground_heat_flux` is the *explicit* snow-free-ground conductive flux
-`G = 2κg(Tg − Ts)/Δzg`, evaluated directly from the current `skin_temperature` (whatever value the state
-holds — a Newton iterate mid-solve, or the converged value) via [`ground_thermal_interface`](@ref). This
-overrides the generic `R_net + H_s + H_l` method above: computing `G` explicitly from conduction (rather
-than deriving it by algebraically inverting the atmosphere-side demand, as a previous implementation did)
-keeps it an unambiguous, always-consistent per-bare-ground-area quantity at every iterate — not only in
-the limit of exact convergence, and not conflated with the whole-cell atmosphere-side demand once a
-separate snow-top conductive term also exists (see [`compute_skin_temperature_residual!`](@ref)).
+Compute the conductive ground heat flux from the current `skin_temperature` and `ground_temperature`.
 """
 @propagate_inbounds function compute_ground_heat_flux(
         i, j, grid, fields,
@@ -237,22 +234,49 @@ end
 """
     $TYPEDSIGNATURES
 
+Invert the (linear) ground-only conduction relation for the implicit skin temperature `Ts` given the
+atmosphere-side demanded flux `G` (`= R_net + H_s + H_l`): `Ts = Tg − G/(2κg/Δzg)`. This is the no-snow
+special case (`f_snow = 0`) of the snow-aware method below; it is a separate method (rather than a default
+`snow = nothing`) purely so it can skip the unused `snow_thermal_interface`/`snow_cover_fraction` calls.
+"""
+@inline function compute_skin_temperature(i, j, grid, fields, skinT::ImplicitSkinTemperature{NF}, args...) where {NF}
+    # Get inputs
+    R_net = fields.surface_net_radiation[i, j, 1]
+    H_s = fields.sensible_heat_flux[i, j, 1]
+    H_l = fields.latent_heat_flux[i, j, 1]
+    G₀ = compute_ground_heat_flux_demand(skinT, R_net, H_s, H_l)
+    Tg, κg, Δzg = ground_thermal_interface(i, j, grid, fields, skinT)
+    Ts = Tg - G₀ * Δzg / (2 * κg)
+    return Ts
+end
+
+"""
+    $TYPEDSIGNATURES
+
 Invert the (linear) area-weighted conduction relation for the implicit skin temperature `Ts` given the
 atmosphere-side demanded flux `G` (`= R_net + H_s + H_l`), by equating `G` to the area-weighted sum of the
-*unblended* ground and snow-top conductive fluxes,
-`(1 − f_snow)·2κg(Tg − Ts)/Δzg + f_snow·2κsnow(Tsnow − Ts)/dsnow`. Since both conductive terms are affine
-in `Ts` (only `G`, via `R_net`/`H`/`LE`, is nonlinear), this closed form is an *exact* solve of the
-conduction side, not an approximation — the same linear-inversion structure used before the `G`/`S` split
-(see [`compute_skin_temperature_residual!`](@ref)), just with the ground and snow terms kept unblended
-rather than combined into a single cover-fraction-weighted conduction target. Without snow (`f_snow = 0`;
-`κsnow`/`Tsnow` unused since their term is weighted out) this reduces exactly to `Ts = Tg − G·Δzg/(2κg)`.
+*unblended* ground and snow-top conductive fluxes, `(1 − f_snow)·2κg(Tg − Ts)/Δzg + f_snow·2κsnow(Tsnow − Ts)/dsnow`.
 """
-@inline function compute_skin_temperature(::ImplicitSkinTemperature, G, Tg, κg, Δzg, f_snow, Tsnow, κsnow, dsnow)
-    Ag = 2 * κg / Δzg
-    As = 2 * κsnow / dsnow
-    A = (one(f_snow) - f_snow) * Ag + f_snow * As
-    B = (one(f_snow) - f_snow) * Ag * Tg + f_snow * As * Tsnow
-    Ts = (B - G) / A
+@inline function compute_skin_temperature(
+        i, j, grid, fields,
+        skinT::ImplicitSkinTemperature{NF},
+        constants::PhysicalConstants,
+        snow::AbstractSnow
+    ) where {NF}
+    # Get inputs
+    R_net = fields.surface_net_radiation[i, j, 1]
+    H_s = fields.sensible_heat_flux[i, j, 1]
+    H_l = fields.latent_heat_flux[i, j, 1]
+    G₀ = compute_ground_heat_flux_demand(skinT, R_net, H_s, H_l)
+    Tg, κg, Δzg = ground_thermal_interface(i, j, grid, fields, skinT)
+    Tsnow, κsnow, dsnow = snow_thermal_interface(i, j, grid, fields, snow, constants)
+    f_snow = snow_cover_fraction(i, j, grid, fields, snow)
+    # Solve for skin temperature
+    Dg = 2 * κg / Δzg
+    Ds = 2 * κsnow / dsnow
+    A = (NF(1) - f_snow) * Dg + f_snow * Ds
+    B = (NF(1) - f_snow) * Dg * Tg + f_snow * Ds * Tsnow
+    Ts = (B - G₀) / A
     return Ts
 end
 
@@ -261,12 +285,7 @@ end
 
 Surface-energy-balance residual at grid cell `i, j`, in temperature space: `Ts_prev − Ts_implicit`, where
 `Ts_implicit` is the exact conduction-side inverse (see [`compute_skin_temperature`](@ref)) of the
-atmosphere-side demanded flux `G_demand = R_net(Ts_prev) + H(Ts_prev) + LE(Ts_prev)`. This keeps the
-solver mechanics (and its tolerance semantics) unchanged from before the `G`/`S` split — the demanded flux
-is recomputed here rather than read back from `ground_heat_flux`, because that field now stores the
-*explicit* bare-ground conductive flux at the current `Ts` (see the `ImplicitSkinTemperature`-specific
-[`compute_ground_heat_flux`](@ref)), not the atmosphere-side demand; the two coincide only at
-convergence. `snow` also partitions the latent flux by area (see [`compute_surface_energy_fluxes!`](@ref)).
+atmosphere-side demanded flux `G_demand = R_net(Ts_prev) + H(Ts_prev) + LE(Ts_prev)`.
 """
 @propagate_inbounds function compute_skin_temperature_residual!(
         out, i, j, grid, fields,
@@ -280,14 +299,7 @@ convergence. `snow` also partitions the latent flux by area (see [`compute_surfa
     # Compute all fluxes at the current Ts (this includes the explicit ground-conduction flux, stored
     # into `ground_heat_flux`); `snow` partitions the latent flux by snow-covered fraction
     compute_surface_energy_fluxes!(out, i, j, grid, fields, seb, constants, atmos, hydrology, snow)
-    R_net = out.surface_net_radiation[i, j, 1]
-    H_s = out.sensible_heat_flux[i, j, 1]
-    H_l = out.latent_heat_flux[i, j, 1]
-    G_demand = compute_ground_heat_flux(skinT, R_net, H_s, H_l)
-    Tg, κg, Δzg = ground_thermal_interface(i, j, grid, fields, skinT)
-    f = snow_cover_fraction(i, j, grid, fields, snow)
-    Tsnow, κsnow, dsnow = snow_conduction_interface(i, j, grid, fields, snow, constants)
-    Ts_implicit = compute_skin_temperature(skinT, G_demand, Tg, κg, Δzg, f, Tsnow, κsnow, dsnow)
+    Ts_implicit = compute_skin_temperature(i, j, grid, fields, skinT, constants, snow)
     Ts_prev = out.skin_temperature[i, j, 1]
     return Ts_prev - Ts_implicit
 end
@@ -312,7 +324,6 @@ end
 
 @kernel function compute_ground_heat_flux_kernel!(out, grid, fields, skinT::AbstractSkinTemperature, args...)
     i, j = @index(Global, NTuple)
-
-    # Compute and store ground heat flux
-    out.ground_heat_flux[i, j, 1] = compute_ground_heat_flux(i, j, grid, fields, skinT, args...)
+    # Forward to mutating compute_ground_heat_flux!
+    compute_ground_heat_flux!(out, i, j, grid, fields, skinT, args...)
 end

--- a/src/processes/surface/skin_temperature.jl
+++ b/src/processes/surface/skin_temperature.jl
@@ -95,14 +95,14 @@ end
 
 Return the conduction target `(Tsnow, κsnow, dsnow)` for the snow-covered fraction: the snow's own
 (bulk) temperature, its thermal conductivity recovered from the density scheme, and its depth floored at
-`min_conduction_thickness`. Without snow (`snow === nothing`), returns a placeholders with `κsnow = 0`
-such that the snow conductive heat flux reduces to zero.
+[`min_snow_conduction_thickness`](@ref). Without snow (`snow === nothing`), returns a placeholders with
+`κsnow = 0` such that the snow conductive heat flux reduces to zero.
 """
 @propagate_inbounds function snow_thermal_interface(i, j, grid, fields, snow::AbstractSnow, constants::PhysicalConstants)
     ρ_snow = compute_snow_density(i, j, grid, fields, snow.density)
     κ_snow = compute_thermal_conductivity(snow, constants.material, ρ_snow)
     T_snow = snow_temperature(i, j, grid, fields, snow)
-    d_snow = max(snow_depth(i, j, grid, fields, snow), snow.min_conduction_thickness)
+    d_snow = max(snow_depth(i, j, grid, fields, snow), min_snow_conduction_thickness(i, j, grid, fields, snow))
     return (T_snow, κ_snow, d_snow)
 end
 # Fallback for case where snow == nothing

--- a/src/processes/surface/skin_temperature.jl
+++ b/src/processes/surface/skin_temperature.jl
@@ -41,13 +41,21 @@ variables(::PrescribedSkinTemperature) = (
 
 Scheme for an implicit skin temperature ``T_s`` satisfying:
 ```math
-R_{\\text{net}}(T_s) + H_s(T_s) + H_l(T_s) - G(T_s, T_g) = 0 
+R_{\\text{net}}(T_s) + H_s(T_s) + H_l(T_s) - (1 - f_{\\text{snow}})\\, G(T_s, T_g) - f_{\\text{snow}}\\, S(T_s, T_{\\text{snow}}) = 0
 ```
 where ``R_{\\text{net}}`` is the net radiation budget, ``H_s`` is the sensible heat flux, ``H_l`` is the latent
-heat flux from sublimation and evapotranspiration, ``G`` is the ground heat flux, and ``T_g`` is the ground
-temperature, or temperature of the uppermost subsurface (soil or snow) layer. All fluxes follow the positive upwards 
-convention. For ``G``, this means from the deeper soil towards the surface is positive. For the other fluxes, this 
-means from the surface towards the atmosphere is positive. 
+heat flux from sublimation and evapotranspiration, ``G`` is the conductive flux from the skin into the
+snow-free ground (``T_g`` its temperature), ``S`` is the conductive flux from the skin into the top of the
+snowpack over the snow-covered fraction (``T_{\\text{snow}}`` its temperature), and ``f_{\\text{snow}}``
+is the snow-covered area fraction (``f_{\\text{snow}} = 0`` and ``S`` absent without snow). ``G`` and
+``S`` are each computed from their own *unblended* conduction target (see
+[`ground_thermal_interface`](@ref) and [`snow_conduction_interface`](@ref)) rather than a single
+cover-fraction-weighted blend of ground and snow properties — this keeps the flux delivered to the
+snow-covered fraction from being diluted (or, for small ``f_{\\text{snow}}``, from being replaced
+outright) by the bare-ground share when computing the snowpack's own top-of-pack energy tendency (see
+[`compute_skin_temperature_residual!`](@ref)). All fluxes follow the positive upwards convention: for
+``G`` and ``S``, this means from the medium below towards the surface is positive; for the other fluxes,
+this means from the surface towards the atmosphere is positive.
 
 Properties:
 $FIELDS
@@ -87,24 +95,12 @@ end
 """
     $TYPEDSIGNATURES
 
-Compute the implicit update of the skin temperature from the sub-surface temperature `Tg`, ground heat
-flux `G`, half-cell distance `Δz`, and effective conductivity `κ`, by equating `G` to the half-cell
-conductive flux `2κ(Tg − Ts)/Δz`.
+Return the conduction target `(Tg, κ, Δz)` for the snow-free ground: the uppermost ground layer's
+`ground_temperature`, the assumed surface conductivity `κₛ`, and the top ground cell thickness. This is
+always the *unblended* ground-only target, used both when there is no snow and (weighted by
+`1 - f_snow`) for the bare-ground share of the skin-temperature solve when there is.
 """
-@inline function compute_skin_temperature(::ImplicitSkinTemperature, Tg, G, Δz, κ)
-    Ts = Tg - G * Δz / (2 * κ)
-    return Ts
-end
-
-"""
-    $TYPEDSIGNATURES
-
-Return the effective conduction target `(Tg, κ, Δz)` seen by the skin-temperature solve: the temperature
-of the medium directly beneath the skin, its thermal conductivity, and the half-cell thickness. Without
-snow (`snow === nothing`) these are the uppermost ground layer's `ground_temperature`, the assumed
-surface conductivity `κₛ`, and the top ground cell thickness — i.e. the snow-free behavior is unchanged.
-"""
-@propagate_inbounds function ground_thermal_interface(i, j, grid, fields, skinT::ImplicitSkinTemperature, args...)
+@propagate_inbounds function ground_thermal_interface(i, j, grid, fields, skinT::ImplicitSkinTemperature)
     field_grid = get_field_grid(grid)
     Δz₁ = Δzᵃᵃᶜ(i, j, field_grid.Nz, field_grid)
     Tg = fields.ground_temperature[i, j]
@@ -114,21 +110,21 @@ end
 """
     $TYPEDSIGNATURES
 
-Snow-covered variant: the conduction target is the snow-cover-fraction-weighted blend of the snow layer
-and the underlying ground, `x_eff = (1 − f_snow)·x_ground + f_snow·x_snow` for the temperature,
-conductivity, and half-cell thickness.
+Return the conduction target `(Tsnow, κsnow, dsnow)` for the snow-covered fraction: the snow's own
+(bulk) temperature, its thermal conductivity recovered from the density scheme, and its depth floored at
+`min_conduction_thickness` (avoids a `0/0` conductance as the pack vanishes — the same floor already used
+for the snow-base flux, see [`compute_snow_basal_heat_flux`](@ref)). Without snow (`snow === nothing`)
+returns a finite placeholder (`κsnow = 0`) so the always-zero `f_snow` weight in
+[`compute_skin_temperature_residual!`](@ref) eliminates this term without risking `0 * Inf = NaN`.
 """
-@propagate_inbounds function ground_thermal_interface(i, j, grid, fields, skinT::ImplicitSkinTemperature, snow::AbstractSnow, constants::PhysicalConstants)
-    field_grid = get_field_grid(grid)
-    Δz_ground = Δzᵃᵃᶜ(i, j, field_grid.Nz, field_grid)
-    f = snow_cover_fraction(i, j, grid, fields, snow)
-    # bulk snow thermal conductivity recovered lazily from the density scheme
+@propagate_inbounds snow_conduction_interface(i, j, grid, fields, ::Nothing, constants::PhysicalConstants) =
+    (zero(eltype(grid)), zero(eltype(grid)), one(eltype(grid)))
+@propagate_inbounds function snow_conduction_interface(i, j, grid, fields, snow::AbstractSnow, constants::PhysicalConstants)
     ρ_snow = compute_snow_density(i, j, grid, fields, snow.density)
     κ_snow = compute_thermal_conductivity(snow, constants.material, ρ_snow)
-    Tg = (one(f) - f) * fields.ground_temperature[i, j] + f * snow_temperature(i, j, grid, fields, snow)
-    κ = (one(f) - f) * skinT.κₛ + f * κ_snow
-    Δz = (one(f) - f) * Δz_ground + f * snow_depth(i, j, grid, fields, snow)
-    return (Tg, κ, Δz)
+    T_snow = snow_temperature(i, j, grid, fields, snow)
+    d_snow = max(snow_depth(i, j, grid, fields, snow), snow.min_conduction_thickness)
+    return (T_snow, κ_snow, d_snow)
 end
 
 """
@@ -165,27 +161,6 @@ end
 """
     $TYPEDSIGNATURES
 
-Compute `skin_temperature` from the current `ground_heat_flux` using the (optionally snow-aware)
-conduction target. `constants` supplies the material properties for the conduction blend; passing a
-`snow` component (default `nothing`) selects the snow-covered [`ground_thermal_interface`](@ref), while
-`snow === nothing` recovers the snow-free soil conduction.
-"""
-function compute_skin_temperature!(
-        state, grid,
-        skinT::ImplicitSkinTemperature,
-        constants::PhysicalConstants,
-        snow::Optional{AbstractSnow} = nothing,
-    )
-    out = prognostic_fields(state, skinT)
-    # merge the (optional) snow thermal auxiliaries so the snow-aware conduction target can be evaluated
-    fields = merge(get_fields(state, skinT; except = out), get_fields(state, snow))
-    launch!(grid, XY, compute_skin_temperature_kernel!, out, fields, skinT, constants, snow)
-    return nothing
-end
-
-"""
-    $TYPEDSIGNATURES
-
 Compute `ground_heat_flux` as the residual ``R_\\text{net} + H_s + H_l`` (all fluxes positive upward).
 """
 function compute_ground_heat_flux!(
@@ -204,27 +179,13 @@ end
 """
     $TYPEDSIGNATURES
 
-Estimate the skin temperature from the current `ground_heat_flux` at grid cell `i, j`, using the
-effective conduction target of the medium below the skin. The optional `snow` argument enables the
-snow-covered blend (see [`ground_thermal_interface`](@ref)); with `snow === nothing` this is the snow-free soil
-conduction.
-"""
-@propagate_inbounds function compute_skin_temperature(
-        i, j, grid, fields,
-        skinT::ImplicitSkinTemperature,
-        constants::PhysicalConstants,
-        snow::Optional{AbstractSnow} = nothing
-    )
-    Tg, κ, Δz = ground_thermal_interface(i, j, grid, fields, skinT, snow, constants)
-    G = fields.ground_heat_flux[i, j]
-    Ts = compute_skin_temperature(skinT, Tg, G, Δz, κ)
-    return Ts
-end
-
-"""
-    $TYPEDSIGNATURES
-
-Compute the ground heat flux from the surface net radiation and sensible/latent heat flux at grid cell `i, j`.
+Compute the ground heat flux from the surface net radiation and sensible/latent heat flux at grid cell
+`i, j`: the flux the atmosphere-side physics *demands* of the surface, `G = R_net + H_s + H_l`. This is
+the generic definition used directly by [`PrescribedSkinTemperature`](@ref) (which has no separate
+conduction target to solve against, so the demanded and stored fluxes coincide by construction) and,
+internally, as the atmosphere-side term of the [`ImplicitSkinTemperature`](@ref) residual (see
+[`compute_skin_temperature_residual!`](@ref)) — but *not* as `ImplicitSkinTemperature`'s own
+`ground_heat_flux` (see the more specific method below).
 """
 @propagate_inbounds function compute_ground_heat_flux(
         i, j, grid, fields,
@@ -243,6 +204,28 @@ end
 """
     $TYPEDSIGNATURES
 
+`ImplicitSkinTemperature`'s `ground_heat_flux` is the *explicit* snow-free-ground conductive flux
+`G = 2κg(Tg − Ts)/Δzg`, evaluated directly from the current `skin_temperature` (whatever value the state
+holds — a Newton iterate mid-solve, or the converged value) via [`ground_thermal_interface`](@ref). This
+overrides the generic `R_net + H_s + H_l` method above: computing `G` explicitly from conduction (rather
+than deriving it by algebraically inverting the atmosphere-side demand, as a previous implementation did)
+keeps it an unambiguous, always-consistent per-bare-ground-area quantity at every iterate — not only in
+the limit of exact convergence, and not conflated with the whole-cell atmosphere-side demand once a
+separate snow-top conductive term also exists (see [`compute_skin_temperature_residual!`](@ref)).
+"""
+@propagate_inbounds function compute_ground_heat_flux(
+        i, j, grid, fields,
+        skinT::ImplicitSkinTemperature,
+        ::AbstractSurfaceEnergyBalance
+    )
+    Tg, κg, Δzg = ground_thermal_interface(i, j, grid, fields, skinT)
+    Ts = fields.skin_temperature[i, j]
+    return 2 * κg * (Tg - Ts) / Δzg
+end
+
+"""
+    $TYPEDSIGNATURES
+
 Per-cell mutating variant used by the fused surface-energy-balance kernel: store the ground heat flux
 into the auxiliary output field `out`.
 """
@@ -254,28 +237,36 @@ end
 """
     $TYPEDSIGNATURES
 
-Recompute surface energy fluxes using [`compute_surface_energy_fluxes!`](@ref) and update the skin temperature
-based on the resulting ground heat flux.
+Invert the (linear) area-weighted conduction relation for the implicit skin temperature `Ts` given the
+atmosphere-side demanded flux `G` (`= R_net + H_s + H_l`), by equating `G` to the area-weighted sum of the
+*unblended* ground and snow-top conductive fluxes,
+`(1 − f_snow)·2κg(Tg − Ts)/Δzg + f_snow·2κsnow(Tsnow − Ts)/dsnow`. Since both conductive terms are affine
+in `Ts` (only `G`, via `R_net`/`H`/`LE`, is nonlinear), this closed form is an *exact* solve of the
+conduction side, not an approximation — the same linear-inversion structure used before the `G`/`S` split
+(see [`compute_skin_temperature_residual!`](@ref)), just with the ground and snow terms kept unblended
+rather than combined into a single cover-fraction-weighted conduction target. Without snow (`f_snow = 0`;
+`κsnow`/`Tsnow` unused since their term is weighted out) this reduces exactly to `Ts = Tg − G·Δzg/(2κg)`.
 """
-@propagate_inbounds function compute_skin_temperature!(
-        out, i, j, grid, fields,
-        skinT::ImplicitSkinTemperature,
-        seb::AbstractSurfaceEnergyBalance,
-        constants::PhysicalConstants,
-        snow::Optional{AbstractSnow} = nothing,
-        seb_args...
-    )
-    # Compute all fluxes based on current skin temperature (this includes ground heat flux already);
-    # `snow` partitions the latent flux by snow-covered fraction
-    compute_surface_energy_fluxes!(out, i, j, grid, fields, seb, constants, seb_args..., snow)
-    out.skin_temperature[i, j, 1] = compute_skin_temperature(i, j, grid, fields, skinT, constants, snow)
-    return nothing
+@inline function compute_skin_temperature(::ImplicitSkinTemperature, G, Tg, κg, Δzg, f_snow, Tsnow, κsnow, dsnow)
+    Ag = 2 * κg / Δzg
+    As = 2 * κsnow / dsnow
+    A = (one(f_snow) - f_snow) * Ag + f_snow * As
+    B = (one(f_snow) - f_snow) * Ag * Tg + f_snow * As * Tsnow
+    Ts = (B - G) / A
+    return Ts
 end
 
 """
     $TYPEDSIGNATURES
 
-Same as [`compute_skin_temperature!`](@ref) but returns the residual instead of updating the `skin_temperature` `Field`.
+Surface-energy-balance residual at grid cell `i, j`, in temperature space: `Ts_prev − Ts_implicit`, where
+`Ts_implicit` is the exact conduction-side inverse (see [`compute_skin_temperature`](@ref)) of the
+atmosphere-side demanded flux `G_demand = R_net(Ts_prev) + H(Ts_prev) + LE(Ts_prev)`. This keeps the
+solver mechanics (and its tolerance semantics) unchanged from before the `G`/`S` split — the demanded flux
+is recomputed here rather than read back from `ground_heat_flux`, because that field now stores the
+*explicit* bare-ground conductive flux at the current `Ts` (see the `ImplicitSkinTemperature`-specific
+[`compute_ground_heat_flux`](@ref)), not the atmosphere-side demand; the two coincide only at
+convergence. `snow` also partitions the latent flux by area (see [`compute_surface_energy_fluxes!`](@ref)).
 """
 @propagate_inbounds function compute_skin_temperature_residual!(
         out, i, j, grid, fields,
@@ -286,11 +277,17 @@ Same as [`compute_skin_temperature!`](@ref) but returns the residual instead of 
         hydrology::Optional{AbstractSurfaceHydrology} = nothing,
         snow::Optional{AbstractSnow} = nothing
     )
-    # Compute all fluxes based on current skin temperature (this includes ground heat flux already);
-    # `snow` partitions the latent flux by snow-covered fraction
+    # Compute all fluxes at the current Ts (this includes the explicit ground-conduction flux, stored
+    # into `ground_heat_flux`); `snow` partitions the latent flux by snow-covered fraction
     compute_surface_energy_fluxes!(out, i, j, grid, fields, seb, constants, atmos, hydrology, snow)
-    # Compute skin temperature using the (optionally snow-aware) conduction target
-    Ts_implicit = compute_skin_temperature(i, j, grid, fields, skinT, constants, snow)
+    R_net = out.surface_net_radiation[i, j, 1]
+    H_s = out.sensible_heat_flux[i, j, 1]
+    H_l = out.latent_heat_flux[i, j, 1]
+    G_demand = compute_ground_heat_flux(skinT, R_net, H_s, H_l)
+    Tg, κg, Δzg = ground_thermal_interface(i, j, grid, fields, skinT)
+    f = snow_cover_fraction(i, j, grid, fields, snow)
+    Tsnow, κsnow, dsnow = snow_conduction_interface(i, j, grid, fields, snow, constants)
+    Ts_implicit = compute_skin_temperature(skinT, G_demand, Tg, κg, Δzg, f, Tsnow, κsnow, dsnow)
     Ts_prev = out.skin_temperature[i, j, 1]
     return Ts_prev - Ts_implicit
 end
@@ -312,12 +309,6 @@ Run a full nonlinear solve to determine the `skin_temperature` at grid cell `i, 
 end
 
 # Kernels
-
-@kernel function compute_skin_temperature_kernel!(out, grid, fields, skinT::ImplicitSkinTemperature, args...)
-    i, j = @index(Global, NTuple)
-
-    out.skin_temperature[i, j, 1] = compute_skin_temperature(i, j, grid, fields, skinT, args...)
-end
 
 @kernel function compute_ground_heat_flux_kernel!(out, grid, fields, skinT::AbstractSkinTemperature, args...)
     i, j = @index(Global, NTuple)

--- a/src/processes/surface/surface_energy_balance.jl
+++ b/src/processes/surface/surface_energy_balance.jl
@@ -127,7 +127,7 @@ skin temperature and humidity fluxes.
     compute_turbulent_fluxes!(out, i, j, grid, fields, seb.turbulent_fluxes, seb.skin_temperature, constants, atmos, hydrology, snow)
     # Ground heat flux closes the balance: G = R_net + H_s + H_l.
     compute_ground_heat_flux!(out, i, j, grid, fields, seb.skin_temperature, seb)
-    return nothing
+    return out
 end
 
 # Kernels (fused)

--- a/src/processes/thermodynamics/enthalpy.jl
+++ b/src/processes/thermodynamics/enthalpy.jl
@@ -11,9 +11,9 @@ Calculate the unfrozen water content from the given internal energy `U` (J/m³) 
 volumetric latent heat content `ρLθ` (J/m³).
 """
 @inline function liquid_water_fraction(::FreeWater, U::NF, ρLθ::NF) where {NF}
-    # Case 1: U ≥ 0 -> thawed (liq = 1)
-    # Case 2a: -ρLθ ≤ U < 0 -> phase change (liq = 1 - U/(-ρLθ))
-    # Case 2b: U < -ρLθ -> frozen (liq = 0), enforced by the (U ≥ -ρLθ) factor.
+    # Case 1: U ≥ 0          → thawed (liq = 1)
+    # Case 2a: -ρLθ ≤ U < 0  → phase change (liq = 1 - U/(-ρLθ))
+    # Case 2b: U < -ρLθ      → frozen (liq = 0), enforced by the (U ≥ -ρLθ) factor.
     return ifelse(
         U >= zero(U),
         NF(1),
@@ -29,8 +29,8 @@ volumetric latent heat content `ρLθ` (J/m³), and volumetric heat capacity `C`
 under the free water freezing characteristic.
 """
 @inline function energy_to_temperature(::FreeWater, U::NF, ρLθ::NF, C::NF) where {NF}
-    # Case 1:  U < -ρLθ      → frozen      (T = (U + ρLθ)/C)
-    # Case 2a: U ≥ 0        → thawed      (T = U/C)
+    # Case 1:  U < -ρLθ      → frozen       (T = (U + ρLθ)/C)
+    # Case 2a: U ≥ 0         → thawed       (T = U/C)
     # Case 2b: -ρLθ ≤ U < 0  → phase change (T = 0)
     return ifelse(
         U < -ρLθ,

--- a/src/timesteppers/cell_diffusion_timescale.jl
+++ b/src/timesteppers/cell_diffusion_timescale.jl
@@ -36,4 +36,7 @@ cell_diffusion_timescale(state, model::SoilModel) =
     cell_diffusion_timescale(state, model.grid, model.soil, model.constants)
 
 cell_diffusion_timescale(state, model::LandModel) =
-    cell_diffusion_timescale(state, model.grid, model.soil, model.constants)
+    min(
+        cell_diffusion_timescale(state, model.grid, model.soil, model.constants),
+        cell_diffusion_timescale(state, model.grid, model.snow, model.constants)
+    )

--- a/src/timesteppers/cell_diffusion_timescale.jl
+++ b/src/timesteppers/cell_diffusion_timescale.jl
@@ -37,6 +37,6 @@ cell_diffusion_timescale(state, model::SoilModel) =
 
 cell_diffusion_timescale(state, model::LandModel) =
     min(
-        cell_diffusion_timescale(state, model.grid, model.soil, model.constants),
-        cell_diffusion_timescale(state, model.grid, model.snow, model.constants)
-    )
+    cell_diffusion_timescale(state, model.grid, model.soil, model.constants),
+    cell_diffusion_timescale(state, model.grid, model.snow, model.constants)
+)

--- a/test/differentiability/snow_model_diff.jl
+++ b/test/differentiability/snow_model_diff.jl
@@ -55,12 +55,45 @@ end
 end
 
 @testset "Snow basal heat flux: differentiability" begin
-    # Q_base = 2·κ·(T_soil − T_snow)/max(d_snow, d_min); gradient w.r.t. the soil temperature is 2·κ/d_snow for d_snow > d_min
-    κ = 0.3
-    d_snow = 0.5
-    d_min = 1.0e-3
-    grad, = Enzyme.autodiff(Reverse, Terrarium.compute_snow_basal_heat_flux, Active, Const(κ), Active(1.0), Const(-2.0), Const(d_snow), Const(d_min))
-    @test grad[2] ≈ 2κ / d_snow
+    # Q_base = (T_soil − T_snow) / (Δz_soil/(2κ_soil) + d_snow/(2κ_snow)), computed by
+    # compute_snow_basal_heat_flux(i, j, grid, fields, snow, soil, constants) from soil/snow state
+    # (κ_soil from soil_composition, κ_snow from the snow density closure). This now depends on the soil
+    # component's state, so differentiate the field-based kernel function directly via Duplicated(state,
+    # dstate), mirroring the closure! pattern in soil_hydrology_diff.jl, rather than a standalone scalar
+    # closure (which no longer exists — the real function reads composition-dependent conductivities).
+    grid = ColumnGrid(CPU(), Float64, ExponentialSpacing(N = 5))
+    soil = SoilEnergyWaterCarbon(Float64)
+    snow = SingleLayerSnow(Float64)
+    land = LandModel(grid; soil, snow, vegetation = nothing)
+    integrator = initialize(
+        land;
+        initializers = (
+            temperature = (x, z) -> -10.0 - 0.01 * z,
+            saturation_water_ice = (x, z) -> 0.8,
+            snow_water_equivalent = 0.05,
+            snow_temperature = -5.0,
+        )
+    )
+    state = integrator.state
+    Terrarium.closure!(state, land)
+    compute_auxiliary!(state, land)
+
+    dstate = make_zero(state)
+    Enzyme.autodiff(
+        set_runtime_activity(Reverse),
+        Terrarium.compute_snow_basal_heat_flux,
+        Active,
+        Const(1), Const(1), Const(grid),
+        Duplicated(state, dstate),
+        Const(snow), Const(soil), Const(land.constants)
+    )
+    dQ_dTsoil = only(Array(interior(dstate.ground_temperature)))
+    dQ_dTsnow = only(Array(interior(dstate.snow_temperature)))
+    @test isfinite(dQ_dTsoil)
+    @test isfinite(dQ_dTsnow)
+    # Q_base is linear in both temperatures with equal and opposite slopes: 1/(R_soil+R_snow)
+    @test dQ_dTsoil > 0
+    @test dQ_dTsoil ≈ -dQ_dTsnow
 end
 
 @testset "Snow model: timestep!" begin

--- a/test/snow/snow_energy_tests.jl
+++ b/test/snow/snow_energy_tests.jl
@@ -89,23 +89,61 @@ using Test
         @test all(state.snow_energy .< 0)
     end
 
-    @testset "basal heat flux: thin-snow depth flooring" begin
-        # Q_base = 2·κ·(T_soil − T_snow)/max(d_snow, d_min): the denominator is floored at d_min so the
-        # flux stays bounded as the snowpack vanishes (an eps offset would let it diverge and destabilize
-        # explicit stepping over frozen soil).
-        κ = NF(0.16)
-        T_soil = NF(-10)   # frozen soil below
-        T_snow = NF(0)
-        d_min = snow.min_conduction_thickness
-        # thick snow (d_snow ≫ d_min): floor inactive, recovers the plain conduction formula
-        d_thick = NF(0.5)
-        @test Terrarium.compute_snow_basal_heat_flux(κ, T_soil, T_snow, d_thick, d_min) ≈ 2κ * (T_soil - T_snow) / d_thick
-        # vanishing snow: flux is finite and set by the d_min floor, not the near-zero depth
-        Q_floor = 2κ * (T_soil - T_snow) / d_min
-        for d_thin in (NF(0), NF(1.0e-9), NF(1.0e-6))
-            Q = Terrarium.compute_snow_basal_heat_flux(κ, T_soil, T_snow, d_thin, d_min)
-            @test isfinite(Q)
-            @test Q ≈ Q_floor
+    @testset "basal heat flux: soil series resistance and thin-snow depth flooring" begin
+        # Q_base = (T_soil − T_snow) / (Δz_soil/(2κ_soil) + max(d_snow, d_min)/(2κ_snow)): the snow-side
+        # conduction thickness is floored at d_min (half the uppermost soil cell thickness) so the flux
+        # stays bounded as the snowpack vanishes, and the soil's own half-cell resistance is included in
+        # series rather than assumed negligible.
+        landgrid = ColumnGrid(CPU(), NF, ExponentialSpacing(N = 5))
+        soil = SoilEnergyWaterCarbon(NF)
+        land = LandModel(landgrid; soil, snow, vegetation = nothing)
+
+        function basal_flux_state(W_snow)
+            initializers = (
+                temperature = (x, z) -> NF(-10) - NF(0.01) * z,
+                saturation_water_ice = (x, z) -> NF(0.8),
+                snow_water_equivalent = W_snow,
+                snow_temperature = NF(0),
+            )
+            integrator = initialize(land; initializers)
+            Terrarium.closure!(integrator.state, land)
+            compute_auxiliary!(integrator.state, land)
+            return integrator.state
+        end
+
+        function expected_flux(state, W_snow)
+            field_grid = Terrarium.get_field_grid(landgrid)
+            k = field_grid.Nz
+            strat = Terrarium.get_stratigraphy(soil)
+            hydrology = Terrarium.get_hydrology(soil)
+            bgc = Terrarium.get_biogeochemistry(soil)
+            energy = Terrarium.get_energy_balance(soil)
+            composition = Terrarium.soil_composition(1, 1, k, landgrid, state, strat, hydrology, bgc)
+            κ_soil = Terrarium.compute_thermal_conductivity(energy.thermal_properties, composition)
+            Δz_soil = Terrarium.Δzᵃᵃᶜ(1, 1, k, field_grid)
+            d_min = Terrarium.min_snow_conduction_thickness(1, 1, landgrid, state, snow)
+            ρ_snow = Terrarium.compute_snow_density(1, 1, landgrid, state, snow.density)
+            κ_snow = Terrarium.compute_thermal_conductivity(snow, constants.material, ρ_snow)
+            d_snow = max(W_snow * ρ_w / ρ_snow, d_min)
+            T_soil = only(Array(interior(state.ground_temperature)))
+            T_snow = only(Array(interior(state.snow_temperature)))
+            R_soil = Δz_soil / (2κ_soil)
+            R_snow = d_snow / (2κ_snow)
+            return (T_soil - T_snow) / (R_soil + R_snow)
+        end
+
+        # thick snow: still finite and matches the series-resistance formula
+        state_thick = basal_flux_state(NF(0.5))
+        Q_thick = Terrarium.compute_snow_basal_heat_flux(1, 1, landgrid, state_thick, snow, soil, constants)
+        @test isfinite(Q_thick)
+        @test Q_thick ≈ expected_flux(state_thick, NF(0.5))
+
+        # vanishing snow: flux stays finite (bounded by the floor) and still matches the formula
+        for W_thin in (NF(0), NF(1.0e-9), NF(1.0e-6))
+            state_thin = basal_flux_state(W_thin)
+            Q_thin = Terrarium.compute_snow_basal_heat_flux(1, 1, landgrid, state_thin, snow, soil, constants)
+            @test isfinite(Q_thin)
+            @test Q_thin ≈ expected_flux(state_thin, W_thin)
         end
     end
 end

--- a/test/snow/snow_model_tests.jl
+++ b/test/snow/snow_model_tests.jl
@@ -58,6 +58,24 @@ using Test
         @test all(state.tendencies.snow_energy .≈ ρ_w * P_s * (c_i * NF(-2) - L_f))
     end
 
+    @testset "snowfall onto bare ground (W=0) advects cold, not zero" begin
+        # Regression test: the conductive-term gate in `compute_snow_energy_tendency` must not also
+        # gate `Q_prcp`, or the very first step of accumulation onto bare ground (W read as 0 before
+        # this step's mass increment) gets zero recorded energy input despite the snow being cold.
+        state = fresh_state()
+        set!(state.snow_water_equivalent, zero(NF))
+        set!(state.snow_temperature, NF(-8))
+        Terrarium.initialize!(state, model.grid, snow, constants)
+        P_s = NF(1.0e-6)
+        set!(state.snowfall, P_s)
+        set!(state.air_temperature, NF(-8))
+        step_tendencies!(state)
+        @test all(state.tendencies.snow_water_equivalent .≈ P_s)
+        # Same advected-cold formula as the W0 > 0 case above: gating must not silently zero this out.
+        @test all(state.tendencies.snow_energy .≈ ρ_w * P_s * (c_i * NF(-8) - L_f))
+        @test all(state.tendencies.snow_energy .< 0)  # cold snow carries negative enthalpy in, not zero
+    end
+
     @testset "fully melted pack drains (SWE + energy decrease)" begin
         state = fresh_state()
         set!(state.snow_water_equivalent, W0)

--- a/test/surface/skin_temperature.jl
+++ b/test/surface/skin_temperature.jl
@@ -92,16 +92,13 @@ function test_skin_temperature_solve!(
     skinT = model.surface_energy_balance.skin_temperature
     snow = hasproperty(model, :snow) ? model.snow : nothing
     Tg, κg, Δzg = Terrarium.ground_thermal_interface(1, 1, grid, state, skinT)
-    f = isnothing(snow) ? zero(NF) : state.snow_cover_fraction[1, 1]
-    Tsnow, κsnow, dsnow = Terrarium.snow_conduction_interface(1, 1, grid, state, snow, model.constants)
     Ts = state.skin_temperature[1, 1]
     G = state.ground_heat_flux[1, 1]
     G_gradient = 2 * κg * (Tg - Ts) / Δzg
     R_net = state.surface_net_radiation[1, 1]
     H_s = state.sensible_heat_flux[1, 1]
     H_l = state.latent_heat_flux[1, 1]
-    G_demand = R_net + H_s + H_l
-    Ts_implicit = Terrarium.compute_skin_temperature(skinT, G_demand, Tg, κg, Δzg, f, Tsnow, κsnow, dsnow)
+    Ts_implicit = Terrarium.compute_skin_temperature(1, 1, grid, state, skinT, model.constants, snow)
     Ts_residual = Ts - Ts_implicit
     G_residual = G - G_gradient
 

--- a/test/surface/skin_temperature.jl
+++ b/test/surface/skin_temperature.jl
@@ -84,32 +84,38 @@ function test_skin_temperature_solve!(
     # Check that the skin temperature is finite and within plausible range
     @test all(isfinite.(state.skin_temperature)) && all(state.skin_temperature .> -100) && all(state.skin_temperature .< 100)
 
-    # Check if ground heat flux converged to gradient flux, using the same blended
-    # thermal interface (Tg, κ, Δz) that the implicit residual function employs.
+    # Check convergence in temperature space, mirroring exactly what `compute_skin_temperature_residual!`
+    # computes: the atmosphere-side demand (R_net + H_s + H_l) inverted through the (unblended) ground and
+    # snow-top conduction targets should reproduce the current skin temperature. Also check that the
+    # *stored* `ground_heat_flux` is the explicit bare-ground conductive flux at that Ts (see the
+    # `ImplicitSkinTemperature`-specific `compute_ground_heat_flux` in skin_temperature.jl).
     skinT = model.surface_energy_balance.skin_temperature
-    if hasproperty(model, :snow)
-        Tg, κ, Δz = Terrarium.ground_thermal_interface(1, 1, grid, state, skinT, model.snow, model.constants)
-    else
-        Tg, κ, Δz = Terrarium.ground_thermal_interface(1, 1, grid, state, skinT)
-    end
+    snow = hasproperty(model, :snow) ? model.snow : nothing
+    Tg, κg, Δzg = Terrarium.ground_thermal_interface(1, 1, grid, state, skinT)
+    f = isnothing(snow) ? zero(NF) : state.snow_cover_fraction[1, 1]
+    Tsnow, κsnow, dsnow = Terrarium.snow_conduction_interface(1, 1, grid, state, snow, model.constants)
     Ts = state.skin_temperature[1, 1]
     G = state.ground_heat_flux[1, 1]
-    G_gradient = -κ * (Ts - Tg) / (Δz / 2)
-    Ts_implicit = Tg - G * Δz / (2 * κ)
+    G_gradient = 2 * κg * (Tg - Ts) / Δzg
+    R_net = state.surface_net_radiation[1, 1]
+    H_s = state.sensible_heat_flux[1, 1]
+    H_l = state.latent_heat_flux[1, 1]
+    G_demand = R_net + H_s + H_l
+    Ts_implicit = Terrarium.compute_skin_temperature(skinT, G_demand, Tg, κg, Δzg, f, Tsnow, κsnow, dsnow)
     Ts_residual = Ts - Ts_implicit
     G_residual = G - G_gradient
 
     results = (
-        skin_temperature = state.skin_temperature[1, 1],
+        skin_temperature = Ts,
         residual = Ts_residual,
-        surface_net_radiation = state.surface_net_radiation[1, 1],
-        latent_heat_flux = state.latent_heat_flux[1, 1],
-        sensible_heat_flux = state.sensible_heat_flux[1, 1],
-        ground_heat_flux = state.ground_heat_flux[1, 1],
+        surface_net_radiation = R_net,
+        latent_heat_flux = H_l,
+        sensible_heat_flux = H_s,
+        ground_heat_flux = G,
         ground_heat_flux_residual = G_residual,
     )
 
-    G_check = abs(G - G_gradient) < tolerance
+    G_check = abs(G_residual) < tolerance
     resid_check = abs(Ts_residual) < tolerance
     Ts_check = Ts_min < results.skin_temperature < Ts_max
 


### PR DESCRIPTION
Fixes #177

The following is a summary of the problems and fixes, generated by Claude :robot:

## Summary
Northern-latitude winter SWE was staying near-zero (<0.001 m) despite persistent sub-zero forcing, with snow that did accumulate sporadically appearing during summer months too. Investigation traced this to four independent bugs spanning the surface energy balance (SEB), snow energy closure, and snow-top conduction discretization. All four are fixed and verified, both in unit/regression tests and in real coupled SpeedyWeather+Terrarium runs (3-month and full 1-year).

## Problems identified
Unweighted bulk SEB flux forcing the snowpack directly. The single, grid-cell-blended skin-temperature solve produced one bulk ground heat flux G (mixing snow/bare-ground temperature, conductivity, and albedo), which was then applied unmediated — with zero f_snow weighting — as the snowpack's own top-of-pack forcing. A cell with 10% snow cover received the full cell-scale flux, driving thin/patchy snow straight through its melting point every step.
Energy-tendency gate suppressing cold-snow advection on the accumulation-onset step. compute_snow_energy_tendency's (W > 0) gate zeroed the entire tendency — including the precipitation-advection term — on the very first step any snow landed on bare ground, so fresh snow entered with zero energy, which the FreeWater closure reads as instantaneously fully melted.
Liquid-fraction/temperature closures sharing an inappropriate floor. energy_to_temperature! computed both snow temperature and liquid fraction from the same min_conduction_thickness-floored volumetric energy. The floor is needed to keep the temperature calculation from blowing up as depth → 0, but it diluted a genuinely cold, thin layer's energy density toward the melting threshold for liquid fraction, causing spurious full melt.
Explicit-Euler numerical instability in the snow-top conductive flux. At the default 5mm min_conduction_thickness, the implied relaxation timescale (~30s) was ~9x shorter than the model's 300s timestep, so snow temperature oscillated wildly (~0°C ↔ ~-70°C) every step. Landing on the warm side snapped snow_liquid_fraction to 1.0 and fired the Darcy meltwater term at its fully-saturated rate, wiping out accumulated SWE in a single step — confirmed via direct per-step tracing in a coupled year-long run (outputs/run_0005).

## Summary of changes
SEB partitioning: skin_temperature.jl now solves the residual with two unblended, area-weighted conductances — G (skin → bare ground) and S (skin → snow top) — instead of one blended term. ground_heat_flux becomes an explicit conductive flux at the converged Ts, and a new surface_heat_flux field (properly f_snow-weighted) drives the snowpack's own tendency, replacing the old unweighted alias.
Energy tendency gate: excludes the cold-snow precipitation-advection term Q_prcp from the (W > 0) gate — it's a pure source term, always well-defined.
Liquid fraction vs. temperature: energy_to_temperature! now computes liquid fraction from the unfloored, depth-integrated energy while temperature keeps the floored path — decoupling two consumers of the same quantity with different numerical needs.
Grid-derived conduction floor: min_conduction_thickness is no longer a hand-tuned struct constant; it's now min_snow_conduction_thickness, computed as half the uppermost soil grid cell's thickness, tying the floor to the grid's own resolution.
Adaptive timestepping: added cell_diffusion_timescale for snow (mirroring the existing soil implementation), wired into LandModel as min(soil_τ, snow_τ) so TimeStepWizard can shrink Δt when the snow conduction stability limit genuinely requires it, rather than relying solely on a fixed floor.
Basal heat flux: compute_snow_basal_heat_flux moved to snow_interfaces.jl and rewritten as a proper series-resistance formula (Q_base = (T_soil − T_snow) / (Δz_soil/2κ_soil + d_snow/2κ_snow)), correctly accounting for the soil's own half-cell resistance instead of assuming it negligible.

## Testing
Full regression suite: 7902/7902 pass (test/snow/*, test/coupled_models/land_model_tests.jl, test/surface/*, including the 7776-case LandModel stress sweep).
Rewritten basal-flux and gate/liquid-fraction regression tests verified against independently reimplemented closed-form formulas.
Differentiability: test/differentiability/snow_model_diff.jl rewritten to differentiate the new field-based compute_snow_basal_heat_flux via Enzyme (Duplicated(state, dstate)), fixing a stale-signature CI failure.
Clean local doc build (docs/make.jl --local --draft), including updated ImplicitSkinTemperature docstring/process page.
Coupled model verification: 3-month (outputs/run_0006) and full 1-year (outputs/run_0008) SpeedyWeather+Terrarium runs analyzed via xarray. Representative seasonal-snow sites (S. Siberia/Mongolia, US Great Plains, Scandinavia) show a physically correct annual cycle — winter accumulation, spring peak, full summer melt-out tracking skin temperature crossing 0°C, autumn re-accumulation — with zero single-step drainage-wipeout events anywhere on the globe over the full year.

## Known limitations
Still solves a single skin temperature/albedo (no full tiling of snow-covered vs. bare-ground sub-fractions); turbulent fluxes remain unpartitioned. Flagged as future work if residual error proves significant.
ground_thermal_interface still uses a constant soil thermal conductivity rather than the soil model's own state-dependent value — a longstanding simplification, scoped as separate future work.
(Full investigation history, all revisions, and design rationale: docs/dev/2026-08/2026-08-27_PLAN_01_snow_seb_partitioning_investigation.md)